### PR TITLE
bug_fix: test | deepmd | task 04.interstitial | "reprod_opt": 【true】

### DIFF
--- a/dpgen/auto_test/lib/util.py
+++ b/dpgen/auto_test/lib/util.py
@@ -60,6 +60,7 @@ def make_work_path(jdata,task,reprod_opt,static,user):
             if 'relax_incar' in jdata.keys():
                 task_type=task_type+'-reprod-relax_incar'
             else:
+                kspacing = jdata['vasp_params']['kspacing']
                 task_type=task_type+'-reprod-k%.2f'% (kspacing)
 
     work_path=os.path.join(task_path, task_type)


### PR DESCRIPTION
error：File "/data1/wanrunj/.conda/envs/python368/lib/python3.6/site-packages/dpgen/auto_test/lib/util.py", line 63, in make_work_path
    task_type=task_type+'-reprod-k%.2f' % (kspacing)
UnboundLocalError: local variable 'kspacing' referenced before assignment

Adding missed assignment for “kspacing”  @amcadmus 