### PR TITLE
add some parameters for SSHSession

### DIFF
--- a/dpgen/dispatcher/SSHContext.py
+++ b/dpgen/dispatcher/SSHContext.py
@@ -27,13 +27,13 @@ class SSHSession (object) :
             self.local_key_passphrase = self.remote_profile['passphrase']
         self.remote_workpath = self.remote_profile['work_path']
         self.ssh = None
-        self.ssh = self._setup_ssh(hostname=self.remote_host,
-                                   port=self.remote_port,
-                                   username=self.remote_uname,
-                                   password=self.remote_password,
-                                   key_filename=self.local_key_filename,
-                                   timeout=self.remote_timeout,
-                                   passphrase=self.local_key_passphrase)
+        self._setup_ssh(hostname=self.remote_host,
+                        port=self.remote_port,
+                        username=self.remote_uname,
+                        password=self.remote_password,
+                        key_filename=self.local_key_filename,
+                        timeout=self.remote_timeout,
+                        passphrase=self.local_key_passphrase)
 
     def ensure_alive(self,
                      max_check = 10,
@@ -44,13 +44,13 @@ class SSHSession (object) :
                 raise RuntimeError('cannot connect ssh after %d failures at interval %d s' %
                                    (max_check, sleep_time))
             dlog.info('connection check failed, try to reconnect to ' + self.remote_host)
-            self.ssh = self._setup_ssh(hostname=self.remote_host,
-                                   port=self.remote_port,
-                                   username=self.remote_uname,
-                                   password=self.remote_password,
-                                   key_filename=self.local_key_filename, 
-                                   timeout=self.remote_timeout,
-                                   passphrase=self.local_key_passphrase)
+            self._setup_ssh(hostname=self.remote_host,
+                            port=self.remote_port,
+                            username=self.remote_uname,
+                            password=self.remote_password,
+                            key_filename=self.local_key_filename,
+                            timeout=self.remote_timeout,
+                            passphrase=self.local_key_passphrase)
             count += 1
             time.sleep(sleep_time)
 

--- a/dpgen/dispatcher/SSHContext.py
+++ b/dpgen/dispatcher/SSHContext.py
@@ -75,8 +75,9 @@ class SSHSession (object) :
         self.ssh = paramiko.SSHClient()
         # ssh_client.load_system_host_keys()
         self.ssh.set_missing_host_key_policy(paramiko.WarningPolicy)
-        self.ssh.connect(hostname, port, username, password,
-                         key_filename, timeout, passphrase)
+        self.ssh.connect(hostname=hostname, port=port,
+                         username=username, password=password,
+                         key_filename=key_filename, timeout=timeout, passphrase=passphrase)
         assert(self.ssh.get_transport().is_active())
         transport = self.ssh.get_transport()
         transport.set_keepalive(60)

--- a/dpgen/remote/RemoteJob.py
+++ b/dpgen/remote/RemoteJob.py
@@ -108,18 +108,38 @@ class SSHSession (object) :
         self.remote_password = None
         if 'password' in self.remote_profile :
             self.remote_password = self.remote_profile['password']
+        self.local_key_filename = None
+        if 'key_filename' in self.remote_profile:
+            self.local_key_filename = self.remote_profile['key_filename']
+        self.remote_timeout = None
+        if 'timeout' in self.remote_profile:
+            self.remote_timeout = self.remote_profile['timeout']
+        self.local_key_passphrase = None
+        if 'passphrase' in self.remote_profile:
+            self.local_key_passphrase = self.remote_profile['passphrase']
         self.remote_workpath = self.remote_profile['work_path']
-        self.ssh = self._setup_ssh(self.remote_host, self.remote_port, username = self.remote_uname,password=self.remote_password)
+        self.ssh = self._setup_ssh(hostname=self.remote_host,
+                                   port=self.remote_port,
+                                   username=self.remote_uname,
+                                   password=self.remote_password,
+                                   key_filename=self.local_key_filename, 
+                                   timeout=self.remote_timeout,
+                                   passphrase=self.local_key_passphrase)
         
     def _setup_ssh(self,
                    hostname,
-                   port, 
-                   username = None,
-                   password = None):
-        ssh_client = paramiko.SSHClient()        
+                   port=22,
+                   username=None,
+                   password=None,
+                   key_filename=None,
+                   timeout=None,
+                   passphrase=None
+                   ):
+        ssh_client = paramiko.SSHClient()
         ssh_client.load_system_host_keys()
         ssh_client.set_missing_host_key_policy(paramiko.WarningPolicy)
-        ssh_client.connect(hostname, port=port, username=username, password=password)
+        ssh_client.connect(hostname, port, username, password,
+                           key_filename, timeout, passphrase)
         assert(ssh_client.get_transport().is_active())
         return ssh_client
 


### PR DESCRIPTION
In this PR, I add some parameters for `SSHSession` from the original `paramiko.SSHClient.connect()`, including `key_filename`(local private key for ssh), `timeout` and `passphrase`(local passphrase for private key). For users' daily usage, the parameters are sometimes used but not supported by dpgen in `machine.json`, so I just add them.