### PR TITLE
Fix bug if cuda_multi_tasks is used

### DIFF
--- a/dpgen/dispatcher/Batch.py
+++ b/dpgen/dispatcher/Batch.py
@@ -155,7 +155,7 @@ class Batch(object) :
             else :
                 # do not support task-wise restart
                 tmp_cmd = ' %s 1>> %s 2>> %s ' % (self.sub_script_cmd(cmd, jj, res), outlog, errlog)
-                ret += 'CUDA_VISIBLE_DEVICES=%d; %s &\n\n' % ((self.cmd_cnt % self.manual_cuda_devices), tmp_cmd)
+                ret += 'export CUDA_VISIBLE_DEVICES=%d; %s &\n\n' % ((self.cmd_cnt % self.manual_cuda_devices), tmp_cmd)
                 self.cmd_cnt += 1
             ret += 'cd %s\n' % self.context.remote_root
             ret += 'test $? -ne 0 && exit 1\n'

--- a/dpgen/dispatcher/Batch.py
+++ b/dpgen/dispatcher/Batch.py
@@ -155,7 +155,7 @@ class Batch(object) :
             else :
                 # do not support task-wise restart
                 tmp_cmd = ' %s 1>> %s 2>> %s ' % (self.sub_script_cmd(cmd, jj, res), outlog, errlog)
-                ret += 'CUDA_VISIBLE_DEVICES=%d %s &\n\n' % ((self.cmd_cnt % self.manual_cuda_devices), tmp_cmd)
+                ret += 'CUDA_VISIBLE_DEVICES=%d; %s &\n\n' % ((self.cmd_cnt % self.manual_cuda_devices), tmp_cmd)
                 self.cmd_cnt += 1
             ret += 'cd %s\n' % self.context.remote_root
             ret += 'test $? -ne 0 && exit 1\n'


### PR DESCRIPTION
The train_command has been replaced in the format { xxxxx }, so if there is not a ";" before it , there will be a bug.

Like

CUDA_VISIBLE_DEVICES=2  { if [ ! -f model.ckpt.index ]; then dp train input.json; else dp train input.json --restart model.ckpt; fi }  1>> train.log 2>> train.log  &
