### PR TITLE
change the default input for cp2k

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ The bold notation of key (such aas **type_map**) means that it's a necessary key
 - repalce `section parameter` in cp2k as `value` with dict. keyword `"_"`
 - `repeat section` in cp2k just need to be written once with repeat parameter as list. 
 
-If you want to use your own paramter, just write a corresponding dictionary. The `COORD` section will be filled by dpgen automatically, therefore do not include this in dictionary. The `OT` or `Diagonization` section is require for semiconductor or metal system. For specific example, have a look on `example` directory.
+If you want to use your own paramter, just write a corresponding dictionary. The `COORD` section will be filled by dpgen automatically, therefore do not include this in dictionary. The `OT` or `Diagonalization` section is require for semiconductor or metal system. For specific example, have a look on `example` directory.
 
 Here are examples for setting:
  ```python

--- a/README.md
+++ b/README.md
@@ -582,6 +582,9 @@ The bold notation of key (such aas **type_map**) means that it's a necessary key
 - replace `section name` in cp2k as `keyword` in dict. . The corresponding value is a `dict`.
 - repalce `section parameter` in cp2k as `value` with dict. keyword `"_"`
 - `repeat section` in cp2k just need to be written once with repeat parameter as list. 
+
+If you want to use your own paramter, just write a corresponding dictionary. The `COORD` section will be filled by dpgen automatically, therefore do not include this in dictionary. The `OT` or `Diagonization` section is require for semiconductor or metal system. For specific example, have a look on `example` directory.
+
 Here are examples for setting:
  ```python
 
@@ -589,19 +592,22 @@ Here are examples for setting:
  #other we have set other parameters in code, if you want to
  #use your own paramter, just write a corresponding dictionary
  "user_fp_params":   {
- "FORCE_EVAL":{
- "DFT":{
- "BASIS_SET_FILE_NAME": "path",
- "POTENTIAL_FILE_NAME": "path"
- }
- "SUBSYS":{
- "KIND":{
- "_": ["N","C","H"],
- "POTENTIAL": ["GTH-PBE-q5","GTH-PBE-q4", "GTH-PBE-q1"],
- "BASIS_SET": ["DZVP-MOLOPT-GTH","DZVP-MOLOPT-GTH","DZVP-MOLOPT-GTH"]
- }
- }
- }
+     "FORCE_EVAL":{
+         "DFT":{
+             "BASIS_SET_FILE_NAME": "path",
+             "POTENTIAL_FILE_NAME": "path",
+             "SCF":{
+                 "OT":{ "keyword":"keyword parameter", "keyword2":"keyword parameter" }
+             }
+         }
+         "SUBSYS":{
+             "KIND":{
+                 "_": ["N","C","H"],
+                 "POTENTIAL": ["GTH-PBE-q5","GTH-PBE-q4", "GTH-PBE-q1"],
+                 "BASIS_SET": ["DZVP-MOLOPT-GTH","DZVP-MOLOPT-GTH","DZVP-MOLOPT-GTH"]
+             }
+         }
+     }
  }
 ```
 

--- a/dpgen/generator/lib/cp2k.py
+++ b/dpgen/generator/lib/cp2k.py
@@ -25,11 +25,7 @@ default_config={
       "SCF": {
         "SCF_GUESS": "ATOMIC",
         "EPS_SCF": "1.0E-6",
-        "MAX_SCF": 50,
-        "OT": {
-          "MINIMIZER": "DIIS",
-          "PRECONDITIONER": "FULL_SINGLE_INVERSE"
-        }
+        "MAX_SCF": 50
       },
       "XC": {
         "XC_FUNCTIONAL": {
@@ -157,7 +153,6 @@ def make_cp2k_input(sys_data, fp_params):
             }
         }
             }
-
     update_dict(default_config, user_config)
     update_dict(default_config, cell_config)
     #output list

--- a/tests/generator/param-pyridine-cp2k.json
+++ b/tests/generator/param-pyridine-cp2k.json
@@ -102,6 +102,14 @@
     "fp_pp_files":	[],
     "user_fp_params":	{
         "FORCE_EVAL":{
+            "DFT":{
+                "SCF": {
+                    "OT": {
+                        "MINIMIZER": "DIIS",
+                        "PRECONDITIONER": "FULL_SINGLE_INVERSE"
+                    }
+                }
+            },
          "SUBSYS":{
              "KIND":{
                 "_": ["N","C","H"],


### PR DESCRIPTION
The OT section is removed from default input, since "OT" and "diagonalization"  are required for semiconductor and metal, respectively. The users should select one of them based on their cases.  The rest of default input is reserved to ensure the correct print in the output which can be parsed by dpdata(like force information)