### PR TITLE
Allow using different parameters for each sys_idx in model deviation

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -624,7 +624,7 @@ def parse_cur_job_sys_revmat(cur_job, sys_idx, use_plm=False):
     sys_revise_values = []
     if 'sys_rev_mat' not in cur_job.keys():
         cur_job['sys_rev_mat'] = {}
-    local_rev = cur_job['sys_rev_mat'].get(sys_idx, {})
+    local_rev = cur_job['sys_rev_mat'].get(str(sys_idx), {})
     if 'lmp' not in local_rev.keys():
         local_rev['lmp'] = {}
     for ii in local_rev['lmp'].keys():
@@ -813,6 +813,7 @@ def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
             total_rev_keys = rev_keys
             total_rev_mat = rev_mat
             if sys_rev is not None:
+                total_rev_mat = []
                 sys_rev_keys, sys_rev_mat, sys_num_lmp = parse_cur_job_sys_revmat(cur_job,
                                                                                   sys_idx=sys_idx[sys_counter],
                                                                                   use_plm=use_plm)


### PR DESCRIPTION
Key `sys_rev_mat` is added to `model_devi_jobs` of `param.json` to support using different parameters for each system selected in `sys_idx` when using `rev_mat` generating Lammps input files, as well as Plumed input. Therefore, users could choose their parameters **according to the properties of initial structure** in exploring steps, in prevention of poor structures with extremely large model deviation.
Unit test is also added, respectively.

An example is shown below:

```json
"model_devi_jobs": [
    {
            "template":{"lmp": "lmp_tmp/input.lammps"},
            "sys_idx": [0, 1],
            "traj_freq": 50,
            "rev_mat":{
                "lmp": {
                    "V_NSTEPS": [50000],
                    "V_TEMP": [100, 200, 300, 400, 500, 600, 700]
                }
            },
            "sys_rev_mat": {
                "0": {"lmp": {"V_DIS": [1.3, 1.6, 1.8], "V_FORCE": [80.0]}},
                "1": {"lmp": {"V_DIS": [3.0, 4.0, 5.0], "V_FORCE": [10.0]}},
            },
            "_idx": 0
        }
]
```