### PR TITLE
add exclude list for LSF

### DIFF
--- a/dpgen/dispatcher/LSF.py
+++ b/dpgen/dispatcher/LSF.py
@@ -123,6 +123,13 @@ class LSF(Batch) :
         ret += '#BSUB -J %s\n' % (res['job_name'] if 'job_name' in res else 'dpgen')
         if len(res['partition']) > 0 :
             ret += '#BSUB -q %s\n' % res['partition']
+        if len(res['exclude_list']) > 0:
+            ret += '#BSUB -R select['
+            temp_exclude = []
+            for ii in res['exclude_list']:
+                temp_exclude.append('hname != %s' % ii)
+            ret += ' && '.join(temp_exclude)
+            ret += ']\n'
         ret += "\n"
         for ii in res['module_unload_list'] :
             ret += "module unload %s\n" % ii


### PR DESCRIPTION
For there is an `exclude_list` for Slurm and the very function could be useful in this PR I include the function for LSF system. With the function, users could exclude some hosts when submitting to their remote cluster in prevention of bad hosts.