### PR TITLE
fix_bug typo in RuntimeError message

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -208,7 +208,7 @@ def make_train (iter_index,
         raise RuntimeError("training_reuse_old_ratio not found but is mandatory when using init-model (training_reuse_iter is detected in param).\n" \
         "It defines the ratio of the old-data picking probability to the all-data(old-data plus new-data) picking probability in training after training_reuse_iter.\n" \
         "Denoting the index of the current iter as N (N >= training_reuse_iter ), old-data refers to those existed before the N-1 iter, and new-data refers to that obtained by the N-1 iter.\n" \
-        "A recommended strategy is making the old-to-new ratio close to 10 times of the default value, to reasonably increase the sensitivity of the model to the new-data.\n" \
+        "A recommended strategy is making the new-to-old ratio close to 10 times of the default value, to reasonably increase the sensitivity of the model to the new-data.\n" \
         "By default, the picking probability of data from one system or one iter is proportional to the number of batches (the number of frames divided by batch_size) of that systems or iter.\n" \
         "Detailed discussion about init-model (in Chinese) please see https://mp.weixin.qq.com/s/qsKMZ0j270YhQKvwXUiFvQ")
 


### PR DESCRIPTION
RuntimeError message when training_reuse_old_ratio not found:
A recommended strategy is making the old-to-new ratio close to 10 times of the default value
--->
A recommended strategy is making the【new-to-old】ratio close to 10 times of the default value