### PR TITLE
fix_bug Lammps.py

### DIFF
--- a/dpgen/auto_test/Lammps.py
+++ b/dpgen/auto_test/Lammps.py
@@ -311,9 +311,9 @@ class Lammps(Task):
             dlog.debug(_tmp)
             type_map_list = lammps.element_list(self.type_map)
 
-            type_list_set = set(type_list)
+            type_map_idx = list(range(len(type_map_list)))
             atom_numbs = []
-            for ii in type_list_set:
+            for ii in type_map_idx:
                 count = 0
                 for jj in type_list:
                     if jj == ii:


### PR DESCRIPTION
error when:
autotest converting lammps/dump containing N elements, when N < len(type_map)

caused by:
assert( len(data['atom_names'])==len(data['atom_numbs']) )
<-- len(data['atom_names']) = len(type_map), len(data['atom_numbs'] = 【len(type_list_set)】
<--【type_list_set = set(type_list), type_list is a list of lammps's atom_type in lammps/dump】

consquence:
can't conduct | dpgen autotest post | relaxation |, when N < len(type_map):

Traceback (most recent call last):
  File "/root/anaconda3/envs/autotest/bin/dpgen", line 8, in <module>
    sys.exit(main())
  File "/root/anaconda3/envs/autotest/lib/python3.7/site-packages/dpgen/main.py", line 175, in main
    args.func(args)
  File "/root/anaconda3/envs/autotest/lib/python3.7/site-packages/dpgen/auto_test/run.py", line 57, in gen_test
    run_task(args.TASK, args.PARAM, args.MACHINE)
  File "/root/anaconda3/envs/autotest/lib/python3.7/site-packages/dpgen/auto_test/run.py", line 44, in run_task
    post_equi(confs, inter_parameter)
  File "/root/anaconda3/envs/autotest/lib/python3.7/site-packages/dpgen/auto_test/common_equi.py", line 190, in post_equi
    res = inter.compute(ii)
  File "/root/anaconda3/envs/autotest/lib/python3.7/site-packages/dpgen/auto_test/Lammps.py", line 371, in compute
    d_dump = loadfn(contcar)
  File "/root/anaconda3/envs/autotest/lib/python3.7/site-packages/monty/serialization.py", line 88, in loadfn
    return json.load(fp, *args, **kwargs)
  File "/root/anaconda3/envs/autotest/lib/python3.7/json/__init__.py", line 296, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/root/anaconda3/envs/autotest/lib/python3.7/json/__init__.py", line 361, in loads
    return cls(**kw).decode(s)
  File "/root/anaconda3/envs/autotest/lib/python3.7/site-packages/monty/json.py", line 343, in decode
    return self.process_decoded(d)
  File "/root/anaconda3/envs/autotest/lib/python3.7/site-packages/monty/json.py", line 318, in process_decoded
    return cls_.from_dict(data)
  File "/root/anaconda3/envs/autotest/lib/python3.7/site-packages/monty/json.py", line 168, in from_dict
    return cls(**decoded)
  File "/root/anaconda3/envs/autotest/lib/python3.7/site-packages/dpdata/system.py", line 995, in __init__
    check_LabeledSystem(data)
  File "/root/anaconda3/envs/autotest/lib/python3.7/site-packages/dpdata/system.py", line 1509, in check_LabeledSystem
    assert( len(data['atom_names'])==len(data['atom_numbs']) )