### PR TITLE
fix KeyError of "job_name" for Slurm

### DIFF
--- a/dpgen/dispatcher/Slurm.py
+++ b/dpgen/dispatcher/Slurm.py
@@ -81,8 +81,9 @@ class Slurm(Batch) :
         ret += "#SBATCH -t %s\n" % res['time_limit']
         if res['mem_limit'] > 0 :
             ret += "#SBATCH --mem=%dG \n" % res['mem_limit']
-        if len(res['job_name']) > 0:
-            ret += '#SBATCH --job-name=%s\n' % res['job_name']
+        if 'job_name' in res:
+            if len(res['job_name']) > 0:
+                ret += '#SBATCH --job-name=%s\n' % res['job_name']
         if len(res['account']) > 0 :
             ret += "#SBATCH --account=%s \n" % res['account']
         if len(res['partition']) > 0 :


### PR DESCRIPTION
In #346 , `job_name` for Slurm was added for a clean task list. However, the modification made the very key a necessary one, or `KeyError` would be raised. So here I fixed the very bug.