### PR TITLE
fix pymatgen v2022.0.* incompatible issue (switch the branch)

### DIFF
--- a/dpgen/auto_test/mpdb.py
+++ b/dpgen/auto_test/mpdb.py
@@ -1,7 +1,7 @@
 import os
 from dpgen import dlog
-from pymatgen import MPRester,Structure
-from pymatgen.ext.matproj import MPRestError 
+from pymatgen.ext.matproj import MPRester, MPRestError
+from pymatgen.core import Structure
 
 web="materials.org"
 

--- a/dpgen/data/gen.py
+++ b/dpgen/data/gen.py
@@ -21,7 +21,7 @@ import dpgen.data.tools.bcc as bcc
 import dpgen.data.tools.diamond as diamond
 import dpgen.data.tools.sc as sc
 from dpgen.generator.lib.vasp import incar_upper
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.io.vasp import Incar
 from dpgen.remote.decide_machine import  decide_fp_machine
 from dpgen import ROOT_PATH

--- a/dpgen/data/surf.py
+++ b/dpgen/data/surf.py
@@ -15,7 +15,7 @@ from dpgen.remote.decide_machine import  decide_fp_machine
 from dpgen.dispatcher.Dispatcher import Dispatcher, make_dispatcher
 #-----PMG---------
 from pymatgen.io.vasp import Poscar
-from pymatgen import Structure,Element
+from pymatgen.core import Structure, Element
 from pymatgen.io.ase import AseAtomsAdaptor
 #-----ASE-------
 from ase.io import read

--- a/dpgen/dispatcher/LSF.py
+++ b/dpgen/dispatcher/LSF.py
@@ -14,7 +14,7 @@ class LSF(Batch) :
         except:
             return JobStatus.terminated
         if job_id == "" :
-            raise RuntimeError("job %s is has not been submitted" % self.remote_root)
+            raise RuntimeError("job %s has not been submitted" % self.context.remote_root)
         ret, stdin, stdout, stderr\
             = self.context.block_call ("bjobs " + job_id)
         err_str = stderr.read().decode('utf-8')

--- a/tests/auto_test/test_elastic.py
+++ b/tests/auto_test/test_elastic.py
@@ -5,7 +5,7 @@ import unittest
 import dpdata
 from monty.serialization import loadfn, dumpfn
 from pymatgen.analysis.elasticity.strain import Strain, Deformation
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.io.vasp import Incar
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/auto_test/test_mpdb.py
+++ b/tests/auto_test/test_mpdb.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import unittest
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from monty.serialization import loadfn,dumpfn
 

--- a/tests/auto_test/test_surface.py
+++ b/tests/auto_test/test_surface.py
@@ -4,7 +4,7 @@ import numpy as np
 import unittest
 import dpdata
 from monty.serialization import loadfn, dumpfn
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.io.vasp import Incar
 from pymatgen.core.surface import SlabGenerator
 

--- a/tests/auto_test/test_vacancy.py
+++ b/tests/auto_test/test_vacancy.py
@@ -4,7 +4,7 @@ import numpy as np
 import unittest
 import dpdata
 from monty.serialization import loadfn, dumpfn
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.io.vasp import Incar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.analysis.defects.core import Vacancy as pmg_Vacancy

--- a/tests/data/test_gen_bulk.py
+++ b/tests/data/test_gen_bulk.py
@@ -1,6 +1,6 @@
 import os,sys,json,glob,shutil
 import unittest
-from pymatgen import Structure,Composition
+from pymatgen.core import Structure, Composition
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 __package__ = 'data'

--- a/tests/data/test_gen_surf.py
+++ b/tests/data/test_gen_surf.py
@@ -1,6 +1,6 @@
 import os,sys,json,glob,shutil
 import unittest
-from pymatgen import Structure,Element
+from pymatgen.core import Structure, Element
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 __package__ = 'data'

--- a/tests/data/test_gen_surf_poscar.py
+++ b/tests/data/test_gen_surf_poscar.py
@@ -1,6 +1,6 @@
 import os,sys,json,glob,shutil
 import unittest
-from pymatgen import Structure,Element
+from pymatgen.core import Structure, Element
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 __package__ = 'data'


### PR DESCRIPTION
Since last weekend, pymatgen released their v2022.0.* version, and as shown on official document, a backwards incompatible change has been introduced. I just followed the instruction official document to fix the incompatible issue for dpgen. Moreover, I checked the history code showing that the fix is supported since v2017.6.24.
Also, a typo error in LSF dispatcher was fixed.