### PR TITLE
fix parameter error for LSF GPU tasks

### DIFF
--- a/dpgen/dispatcher/LSF.py
+++ b/dpgen/dispatcher/LSF.py
@@ -111,10 +111,10 @@ class LSF(Batch) :
                 # supported in LSF >= 10.1.0 SP6
                 # ref: https://www.ibm.com/support/knowledgecenter/en/SSWRJV_10.1.0/lsf_resource_sharing/use_gpu_res_reqs.html
                 ret += '#BSUB -n %d\n#BSUB -gpu "num=%d:mode=shared:j_exclusive=yes"\n' % (
-                    res['numb_gpu'], res['task_per_node'])
+                    res['task_per_node'], res['numb_gpu'])
             else:
                 ret += '#BSUB -n %d\n#BSUB -R "select[ngpus >0] rusage[ngpus_excl_p=%d]"\n' % (
-                    res['numb_gpu'], res['task_per_node'])
+                    res['task_per_node'], res['numb_gpu'])
         if res['time_limit']:
             ret += '#BSUB -W %s\n' % (res['time_limit'].split(':')[
                 0] + ':' + res['time_limit'].split(':')[1])


### PR DESCRIPTION
For GPU tasks , the positions of two parameters `task_per_node` and `numb_gpu` were written wrongly, causing tasks in `PEND` state. So here they are corrected.