### PR TITLE
rename `n_neuron` to `neuron`

### DIFF
--- a/examples/run/dp1.x-lammps-cp2k/methane/param-ch4.json
+++ b/examples/run/dp1.x-lammps-cp2k/methane/param-ch4.json
@@ -48,7 +48,7 @@
         "seed": 1
         },
         "fitting_net": {
-        "n_neuron": [
+        "neuron": [
             120, 
             120, 
             120


### PR DESCRIPTION
A bug in DeePMD-kit v1.3.0 ~ v1.3.3 will ignore `n_neuron` (deepmodeling/deepmd-kit#846). Rename to prevent some one uses these versions.

@robinzyb 