### PR TITLE
Update gen.py | compatibility with VASP

### DIFF
--- a/dpgen/data/gen.py
+++ b/dpgen/data/gen.py
@@ -534,6 +534,8 @@ def coll_vasp_md(jdata) :
                     #dlog.info("md_nstep", md_nstep)
                     if nforce == md_nstep :
                         valid_outcars.append(outcar)
+                    elif md_nstep == 0 and nforce == 1 :
+                        valid_outcars.append(outcar)
                     else:
                         dlog.info("WARNING : in directory %s nforce in OUTCAR is not equal to settings in INCAR"%(os.getcwd()))
         arg_cvt = " "


### PR DESCRIPTION
for INCAR param of VASP, NSW = 0 and 1 both lead to the output of 1 converged SCF, thus 1 valid frame of labeled data. 
NSW = 0 (actually single-point calculation) was not supported to be used as the "md_incar".
Though, the previous limitation might be reasonable in semantics, this update just support the practical branching in VASP settings and eliminates the annoying exception for users.