### PR TITLE
bug_fix | init_bulk | stages 3 | lost the last pert-dir in stages 2

### DIFF
--- a/dpgen/data/gen.py
+++ b/dpgen/data/gen.py
@@ -464,7 +464,7 @@ def make_vasp_md(jdata, mdata) :
 
     for ii in sys_ps :
         for jj in scale :
-            for kk in range(pert_numb) :
+            for kk in range(pert_numb+1) :
                 path_work = path_md
                 path_work = os.path.join(path_work, ii)
                 path_work = os.path.join(path_work, "scale-%.3f" % jj)


### PR DESCRIPTION
pert_numb = jdata['pert_numb'] 

stages 2 pert makes 000000+pert_numb structures (dirs),  pert_numb + 1 in total
stages 3 was copying those in range(pert_numb), the first  pert_numb structures(dir), lost the last one.