### PR TITLE
Get from_poscar_path only when from_poscar is true

### DIFF
--- a/dpgen/data/gen.py
+++ b/dpgen/data/gen.py
@@ -80,9 +80,9 @@ def out_dir_name(jdata) :
     from_poscar = False
     if 'from_poscar' in jdata :
         from_poscar = jdata['from_poscar']
-        from_poscar_path = jdata['from_poscar_path']
 
     if from_poscar:
+        from_poscar_path = jdata['from_poscar_path']
         poscar_name = os.path.basename(from_poscar_path)
         cell_str = "%02d" % (super_cell[0])
         for ii in range(1,len(super_cell)) :


### PR DESCRIPTION
When running init_bulk, `from_poscar_path` param is actually not necessary if `from_poscar` is False. But now the job will fail in the absence of `from_poscar_path`.

------------
Traceback (most recent call last):
  File "/usr/local/bin/dpgen", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/dist-packages/dpgen/main.py", line 175, in main
    args.func(args)
  File "/usr/local/lib/python3.7/dist-packages/dpgen/data/gen.py", line 702, in gen_init_bulk
    out_dir = out_dir_name(jdata)
  File "/usr/local/lib/python3.7/dist-packages/dpgen/data/gen.py", line 81, in out_dir_name
    from_poscar_path = jdata['from_poscar_path']
KeyError: 'from_poscar_path'