### PR TITLE
Change mv to cp when downloading softlinks.

### DIFF
--- a/dpgen/dispatcher/LocalContext.py
+++ b/dpgen/dispatcher/LocalContext.py
@@ -117,7 +117,13 @@ class LocalContext(object) :
                         pass
                     elif (os.path.exists(rfile)) and (not os.path.exists(lfile)) :
                         # trivial case, download happily
-                        shutil.move(rfile, lfile)
+                        # If the file to be downloaded is a softlink, `cp` should be performed instead of `mv`.
+                        # Otherwise, `lfile` is still a file linked to some original file,
+                        # and when this file's removed, `lfile` will be invalid.
+                        if os.path.islink(rfile):
+                            shutil.copyfile(rfile,lfile)
+                        else:
+                            shutil.move(rfile, lfile)
                     elif (os.path.exists(rfile)) and (os.path.exists(lfile)) :
                         # both exists, replace!
                         dlog.info('find existing %s, replacing by %s' % (lfile, rfile))


### PR DESCRIPTION
If the file to be downloaded is a softlink, `cp` should be performed instead of `mv`. Otherwise, `lfile` is still a file linked to some original file, and when this file's removed, `lfile` will be invalid.