### PR TITLE
autotest: rename task directory to avoid false result in a rerun

### DIFF
--- a/dpgen/auto_test/common_equi.py
+++ b/dpgen/auto_test/common_equi.py
@@ -12,6 +12,8 @@ from dpgen.dispatcher.Dispatcher import make_dispatcher
 from distutils.version import LooseVersion
 from dpgen.dispatcher.Dispatcher import make_submission
 from dpgen.remote.decide_machine import convert_mdata
+from dpgen.auto_test.lib.utils import create_path
+
 lammps_task_type = ['deepmd', 'meam', 'eam_fs', 'eam_alloy']
 
 
@@ -77,10 +79,7 @@ def make_equi(confs,
         if not os.path.exists(poscar):
             raise FileNotFoundError('no configuration for autotest')
         relax_dirs = os.path.abspath(os.path.join(ii, 'relaxation', 'relax_task'))    # to be consistent with property in make dispatcher
-        if os.path.exists(relax_dirs):
-            dlog.warning('%s already exists' % relax_dirs)
-        else:
-            os.makedirs(relax_dirs)
+        create_path(relax_dirs)
         task_dirs.append(relax_dirs)
         os.chdir(relax_dirs)
         # copy POSCARs to mp-xxx/relaxation/relax_task

--- a/dpgen/auto_test/common_prop.py
+++ b/dpgen/auto_test/common_prop.py
@@ -15,6 +15,7 @@ from dpgen.auto_test.calculator import make_calculator
 from dpgen.dispatcher.Dispatcher import make_dispatcher
 from dpgen.dispatcher.Dispatcher import make_submission
 from dpgen.remote.decide_machine import convert_mdata
+from dpgen.auto_test.lib.utils import create_path
 lammps_task_type = ['deepmd', 'meam', 'eam_fs', 'eam_alloy']
 
 
@@ -73,10 +74,7 @@ def make_property(confs,
             path_to_equi = os.path.join(ii, 'relaxation', 'relax_task')
             path_to_work = os.path.join(ii, property_type + '_' + suffix)
 
-            if os.path.exists(path_to_work):
-                dlog.warning('%s already exists' % path_to_work)
-            else:
-                os.makedirs(path_to_work)
+            create_path(path_to_work)
 
             prop = make_property_instance(jj)
             task_list = prop.make_confs(path_to_work, path_to_equi, do_refine)


### PR DESCRIPTION
If we rerun `dpgen autotest make param.json` and there are already task dirs in work directory, it only deletes and reproduces some input files like POSCAR,  but leaves behind result files in last run like OUTCAR.  Next when we run `dpgen autotest run param.json`, it will skip the task directories which already have the result files, and this may leads to a false data.

Change-Id: Ia138ee7c31b6c41d9f41f5943affa9ebf8803c46