### PR TITLE
autotest: fix early return and result checking

### DIFF
--- a/dpgen/auto_test/common_prop.py
+++ b/dpgen/auto_test/common_prop.py
@@ -112,6 +112,7 @@ def run_property(confs,
     conf_dirs.sort()
     task_list = []
     work_path_list = []
+    multiple_ret = []
     for ii in conf_dirs:
         sepline(ch=ii, screen=True)
         for jj in property_list:
@@ -159,7 +160,7 @@ def run_property(confs,
             all_task = tmp_task_list
             run_tasks = util.collect_task(all_task, inter_type)
             if len(run_tasks) == 0:
-                return
+                continue
             else:
                 ret = pool.apply_async(worker, (work_path,
                                                 all_task,
@@ -169,23 +170,13 @@ def run_property(confs,
                                                 mdata,
                                                 inter_type,
                                                 ))
-            # run_tasks = [os.path.basename(ii) for ii in all_task]
-            # machine, resources, command, group_size = util.get_machine_info(mdata, inter_type)
-            # disp = make_dispatcher(machine, resources, work_path, run_tasks, group_size)
-            # disp.run_jobs(resources,
-            #               command,
-            #               work_path,
-            #               run_tasks,
-            #               group_size,
-            #               forward_common_files,
-            #               forward_files,
-            #               backward_files,
-            #               outlog='outlog',
-            #               errlog='errlog')
+                multiple_ret.append(ret)
     pool.close()
     pool.join()
-    if ret.successful():
-        print('finished')
+    for ii in range(len(multiple_ret)):
+        if not multiple_ret[ii].successful():
+            raise RuntimeError("Job %d is not successful!" % ii)
+    print('%d jobs are finished' % len(multiple_ret))
 
 
 def worker(work_path,


### PR DESCRIPTION
There're two issues in run_property():
1. If there is not task to be run for a property(may have already been done in last run), we should skip it and run other properties instead of return.
2. All the results had better to be checked instead of only the last one.

Change-Id: I4430b2c2e20da6cb28640dbc6139e62bed5357a2