### PR TITLE
remove jr.json to allow rerun in autotest make

### DIFF
--- a/dpgen/auto_test/common_equi.py
+++ b/dpgen/auto_test/common_equi.py
@@ -79,6 +79,9 @@ def make_equi(confs,
         poscar = os.path.abspath(os.path.join(ii, 'POSCAR'))
         if not os.path.exists(poscar):
             raise FileNotFoundError('no configuration for autotest')
+        if os.path.exists(os.path.join(ii, 'relaxation', 'jr.json')):
+            os.remove(os.path.join(ii, 'relaxation', 'jr.json'))
+
         relax_dirs = os.path.abspath(os.path.join(ii, 'relaxation', 'relax_task'))    # to be consistent with property in make dispatcher
         create_path(relax_dirs)
         task_dirs.append(relax_dirs)


### PR DESCRIPTION
In commit 0cb32d6d, we will create a new directory `relaxation/relax_task` in `dpgen autotest make relaxation.json`, but leave the old `jr.json` file. If we run `autotest run` next, it may exit with doing nothing after checking jr.json.
Change-Id: I26e8f7120703f131ffb005e4c0c927c108821ae0