### PR TITLE
change compress level to 6 from default 9 to accelerate compress

### DIFF
--- a/dpgen/dispatcher/SSHContext.py
+++ b/dpgen/dispatcher/SSHContext.py
@@ -280,7 +280,7 @@ class SSHContext (object):
         os.chdir(self.local_root)
         if os.path.isfile(of) :
             os.remove(of)
-        with tarfile.open(of, "w:gz", dereference = dereference) as tar:
+        with tarfile.open(of, "w:gz", dereference = dereference, compresslevel=6) as tar:
             for ii in files :
                 tar.add(ii)
         os.chdir(cwd)


### PR DESCRIPTION
In some case, FP calculations could read the wave function file or charge files (e.g., CHGCAR and WAVECAR in VASP ). If the size of those files is too big, the compress process could be very slow due to the default setting (compresslevel=9) in tarfile module of python. Change the compresslevel to 6 will accelate compress rate. 