### PR TITLE
init_bulk: skip relax if skip_relax is true

### DIFF
--- a/dpgen/data/gen.py
+++ b/dpgen/data/gen.py
@@ -769,13 +769,14 @@ def gen_init_bulk(args) :
             dlog.info("Current stage is 1, relax")
             create_path(out_dir)
             shutil.copy2(args.PARAM, os.path.join(out_dir, 'param.json'))
+            skip_relax = jdata['skip_relax']
             if from_poscar :
                 make_super_cell_poscar(jdata)
             else :
                 make_unit_cell(jdata)
                 make_super_cell(jdata)
                 place_element(jdata)
-            if args.MACHINE is not None:
+            if args.MACHINE is not None and not skip_relax:
                make_vasp_relax(jdata, mdata)
                run_vasp_relax(jdata, mdata)
             else:


### PR DESCRIPTION
Now `skip_relax` is only checked in stage 2 (perturb and scale) and use an unrelaxed POSCAR.  It also should be checked in stage 1 to skip the relaxation job.

Change-Id: I12cc467e5956a5deb29ac4bd43719db1c0ef8942