### PR TITLE
model_devi | sort models in default&support user-defined order

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -947,7 +947,7 @@ def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
                 # revise input of lammps
                 with open('input.lammps') as fp:
                     lmp_lines = fp.readlines()
-                # only revise the line "pair deepmd" if the user has not written the full line (checked by then length of the line)
+                # only revise the line "pair_style deepmd" if the user has not written the full line (checked by then length of the line)
                 template_has_pair_deepmd=1
                 for line_idx,line_context in enumerate(lmp_lines):
                     if (line_context[0] != "#") and ("pair_style" in line_context) and ("deepmd" in line_context):
@@ -960,7 +960,7 @@ def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
                     else:
                         if len(lmp_lines[template_pair_deepmd_idx].split()) != (len(models) + len(["pair_style","deepmd","out_freq", "10", "out_file", "model_devi.out"])):
                             lmp_lines = revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version = deepmd_version)
-                #use revise_lmp_input_model to raise error message "part_style" or "deepmd" not found
+                #use revise_lmp_input_model to raise error message if "part_style" or "deepmd" not found
                 else:
                     lmp_lines = revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version = deepmd_version)
                 

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -947,30 +947,28 @@ def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
                 # revise input of lammps
                 with open('input.lammps') as fp:
                     lmp_lines = fp.readlines()
+                # only revise the line "pair deepmd" if the user has not written the full line (checked by then length of the line)
+                template_has_pair_deepmd=1
+                for line_idx,line_context in enumerate(lmp_lines):
+                    if (line_context[0] != "#") and ("pair_style" in line_context) and ("deepmd" in line_context):
+                        template_has_pair_deepmd=0
+                        template_pair_deepmd_idx=line_idx
+                if template_has_pair_deepmd == 0:
+                    if LooseVersion(deepmd_version) < LooseVersion('1'):
+                        if len(lmp_lines[template_pair_deepmd_idx].split()) !=  (len(models) + len(["pair_style","deepmd","10", "model_devi.out"])):
+                            lmp_lines = revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version = deepmd_version)
+                    else:
+                        if len(lmp_lines[template_pair_deepmd_idx].split()) != (len(models) + len(["pair_style","deepmd","out_freq", "10", "out_file", "model_devi.out"])):
+                            lmp_lines = revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version = deepmd_version)
+                #use revise_lmp_input_model to raise error message "part_style" or "deepmd" not found
+                else:
+                    lmp_lines = revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version = deepmd_version)
                 
-				# only revise the line "pair deepmd" if the user has not written the full line (checked by then length of the line)
-				template_has_pair_deepmd=1
-				for line_idx,line_context in enumerate(lmp_lines):
-					if (line_context[0] != "#") and ("pair_style" in line_context) and ("deepmd" in line_context):
-						template_has_pair_deepmd=0
-						template_pair_deepmd_idx=line_idx
-				if template_has_pair_deepmd == 0:
-					if LooseVersion(deepmd_version) < LooseVersion('1'):
-						if len(lmp_lines[template_pair_deepmd_idx].split()) !=  (len(models) + len(["pair_style","deepmd","10", "model_devi.out"])):
-							lmp_lines = revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version = deepmd_version)
-					else:
-						if len(lmp_lines[template_pair_deepmd_idx].split()) != (len(models) + len(["pair_style","deepmd","out_freq", "10", "out_file", "model_devi.out"])):
-							lmp_lines = revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version = deepmd_version)
-				#use revise_lmp_input_model to raise error message "part_style" or "deepmd" not found
-				else:
-					lmp_lines = revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version = deepmd_version)
-				
-				lmp_lines = revise_lmp_input_dump(lmp_lines, trj_freq)
-				lmp_lines = revise_by_keys(
-					lmp_lines, total_rev_keys[:total_num_lmp], total_rev_item[:total_num_lmp]
-				)                        
-                
-				# revise input of plumed
+                lmp_lines = revise_lmp_input_dump(lmp_lines, trj_freq)
+                lmp_lines = revise_by_keys(
+                    lmp_lines, total_rev_keys[:total_num_lmp], total_rev_item[:total_num_lmp]
+                )
+                # revise input of plumed
                 if use_plm:
                     lmp_lines = revise_lmp_input_plm(lmp_lines, 'input.plumed')
                     shutil.copyfile(plm_templ, 'input.plumed')


### PR DESCRIPTION
current behavior:
1）the list of models written in input.lammps for model_devi is created by "glob" without "sort" --> may give different (random) orders in different machine environments  --> would randomly alter the model being used to sample configurations (always use the first model written in imput.lammps)
---> could lead to unexpected performance, such as, when using together with "model_devi_activation_func" that allows four models to be nonequivalent.
2）when preparing input.lammps from iuser-provided template, the line begin with "pair_style deepmd" will be overwritten by dpgen, thus overwrites the user defined order of models ---> could lead to unexpected performance, such as, when using together with "model_devi_activation_func" that allows four models to be nonequivalent and users indeed expected a specific order of models.

changes:
1）sorted the list of models in default, thus always use graph.000.pb to sample configurations;
2）check weather user writes the full line of begin with "pair_style deepmd" (by checking the number of non-space words in this line),  if yes, leave it be; if not, overwrites with the default settings (use graph.000.pb to sample); besides, the original error trigger is retained if key words "pair_style deepmd" are not provided in the template.