### PR TITLE
Add `minimize` step with `fix   1 all box/relax tri 0.0` to autotest/relax step

### DIFF
--- a/dpgen/auto_test/lib/lammps.py
+++ b/dpgen/auto_test/lib/lammps.py
@@ -241,6 +241,8 @@ def make_lammps_equi(conf, type_map, interaction, param,
         ret += "fix             1 all box/relax iso 0.0 \n"
         ret += "minimize        %e %e %d %d\n" % (etol, ftol, maxiter, maxeval)
         ret += "fix             1 all box/relax aniso 0.0 \n"
+        ret += "minimize        %e %e %d %d\n" % (etol, ftol, maxiter, maxeval)
+        ret += "fix             1 all box/relax tri 0.0 \n"
     ret += "minimize        %e %e %d %d\n" % (etol, ftol, maxiter, maxeval)
     ret += "variable        N equal count(all)\n"
     ret += "variable        V equal vol\n"


### PR DESCRIPTION
During autotest/relax step: 
When relaxing a triclinic box, the pressure can end up very anisotropic. 
For example: 
`Final Stress (xx yy zz xy xz yz) = -6.54285676374595 2.85385865753648 -1.07361374379044 353.418222921755 0.00210235362285298 -0.0024651880433958`

A minimization step with `fix 1 all box/relax tri 0.0` managed to release this anisotropic stress, with the final stress:
`Final Stress (xx yy zz xy xz yz) = -0.323181273059006 -0.201582310289252 0.0211419458954172 -0.169653424252636 -0.000554247444608351 0.000443690277947729`