### PR TITLE
bug fix

### DIFF
--- a/dpgen/generator/lib/pwscf.py
+++ b/dpgen/generator/lib/pwscf.py
@@ -127,6 +127,9 @@ def _make_pwscf_04_kpoints(sys_data, kspacing):
     kpoints = [(np.ceil(2 * np.pi * np.linalg.norm(ii) / kspacing).astype(int))
                for ii in rcell]
     ret = ""
+    if kpoints == [1,1,1]:
+        ret += "K_POINTS gamma"
+    else:
     ret += "K_POINTS { automatic }\n"
     for ii in range(3) :
         ret += "%d " % kpoints[ii]

--- a/dpgen/generator/lib/pwscf.py
+++ b/dpgen/generator/lib/pwscf.py
@@ -130,11 +130,11 @@ def _make_pwscf_04_kpoints(sys_data, kspacing):
     if kpoints == [1,1,1]:
         ret += "K_POINTS gamma"
     else:
-    ret += "K_POINTS { automatic }\n"
-    for ii in range(3) :
-        ret += "%d " % kpoints[ii]
-    for ii in range(3) :
-        ret += "%d " % _kshift(kpoints[ii])
+        ret += "K_POINTS { automatic }\n"
+        for ii in range(3) :
+            ret += "%d " % kpoints[ii]
+        for ii in range(3) :
+            ret += "%d " % _kshift(kpoints[ii])
     ret += "\n"
     return ret
 

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -389,6 +389,8 @@ def make_train (iter_index,
             if jinput['model']['descriptor']['type'] == 'hybrid':
                 for desc in jinput['model']['descriptor']['list']:
                     desc['seed'] = random.randrange(sys.maxsize) % (2**32)
+            elif jinput['model']['descriptor']['type'] == 'loc_frame':
+                pass
             else:
                 jinput['model']['descriptor']['seed'] = random.randrange(sys.maxsize) % (2**32)
             jinput['model']['fitting_net']['seed'] = random.randrange(sys.maxsize) % (2**32)


### PR DESCRIPTION
Two fixes
(1) run.py automatically add 'seed' label to descriptor section of the training input. This conflicts with the 'loc_frame' descriptor in DP2.

(2) The input generator of PWSCF should convert "K_POINTS { automatic } \n 1 1 1 0 0 0" to "K_POINTS gamma". The latter switches on the gamma-only algorithm that is two times faster. 