### PR TITLE
Fix the usage of `pair_coeff` in `auto_test`

### DIFF
--- a/dpgen/auto_test/lib/lammps.py
+++ b/dpgen/auto_test/lib/lammps.py
@@ -115,7 +115,7 @@ def inter_deepmd(param):
             ret += "%s out_freq 10 out_file model_devi.out\n" % model_list
         else:
             ret += models[0] + '\n'
-    ret += "pair_coeff\n"
+    ret += "pair_coeff * *\n"
     return ret
 
 


### PR DESCRIPTION
See https://github.com/deepmodeling/dpgen/pull/567 and https://github.com/deepmodeling/dpgen/issues/697