### PR TITLE
correct the wrong spelling of 'failure'

### DIFF
--- a/dpgen/dispatcher/DispatcherList.py
+++ b/dpgen/dispatcher/DispatcherList.py
@@ -45,7 +45,7 @@ class DispatcherList():
                  mark_failure = False,
                  outlog = 'log',
                  errlog = 'err'):
-        ratio_failure = self.mdata_resources.get("ratio_failue", 0)
+        ratio_failure = self.mdata_resources.get("ratio_failure", 0)
         while True:
             if self.check_all_dispatchers_finished(ratio_failure):
                 self.clean()
@@ -188,7 +188,7 @@ class DispatcherList():
 
 
     # Base
-    def check_dispatcher_status(self, ii, allow_failue=False):
+    def check_dispatcher_status(self, ii, allow_failure=False):
         '''catch running dispatcher exception
            if no exception occured, check finished'''
         if self.dispatcher_list[ii]["dispatcher_status"] == "running":
@@ -198,7 +198,7 @@ class DispatcherList():
                 clean = self.mdata_resources.get("clean", False)
                 try:
                     # avoid raising ssh exception in download proceess
-                    finished = self.dispatcher_list[ii]["dispatcher"].all_finished(self.dispatcher_list[ii]["entity"].job_handler, allow_failue, clean)
+                    finished = self.dispatcher_list[ii]["dispatcher"].all_finished(self.dispatcher_list[ii]["entity"].job_handler, allow_failure, clean)
                     if finished:
                         self.dispatcher_list[ii]["dispatcher_status"] = "finished"
                 except Exception:

--- a/examples/machine/DeePMD-kit-1.0/machine-local-4GPU.json
+++ b/examples/machine/DeePMD-kit-1.0/machine-local-4GPU.json
@@ -64,7 +64,7 @@
       },
       "resources": {
         "allow_failure": true,
-        "ratio_failue":  0.05,
+        "ratio_failure":  0.05,
         "task_per_node": 16,
         "with_mpi":      true,
         "_comment" : "Load the intel compiler.",


### PR DESCRIPTION
In [issue#485](https://github.com/deepmodeling/dpgen/issues/485) the wrong spelling of 'failure' was found.