### PR TITLE
fix ‘post_fp_cp2k’, add param rfailed

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -2995,7 +2995,10 @@ def post_fp_gaussian (iter_index,
 
 
 def post_fp_cp2k (iter_index,
-                      jdata):
+                      jdata,
+                      rfailed=None):
+                      
+    ratio_failed =  rfailed if rfailed else jdata.get('ratio_failed',0.05)
     model_devi_jobs = jdata['model_devi_jobs']
     assert (iter_index < len(model_devi_jobs))
 

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -2998,7 +2998,7 @@ def post_fp_cp2k (iter_index,
                       jdata,
                       rfailed=None):
                       
-    ratio_failed =  rfailed if rfailed else jdata.get('ratio_failed',0.05)
+    ratio_failed =  rfailed if rfailed else jdata.get('ratio_failed',0.10)
     model_devi_jobs = jdata['model_devi_jobs']
     assert (iter_index < len(model_devi_jobs))
 
@@ -3029,7 +3029,7 @@ def post_fp_cp2k (iter_index,
         all_sys = None
         for oo in sys_output :
             _sys = dpdata.LabeledSystem(oo, fmt = 'cp2k/output')
-            _sys.check_type_map(type_map = jdata['type_map'])
+            #_sys.check_type_map(type_map = jdata['type_map'])
             if all_sys is None:
                 all_sys = _sys
             else:
@@ -3041,8 +3041,12 @@ def post_fp_cp2k (iter_index,
             sys_data_path = os.path.join(work_path, 'data.%s'%ss)
             all_sys.to_deepmd_raw(sys_data_path)
             all_sys.to_deepmd_npy(sys_data_path, set_size = len(sys_output))
-    dlog.info("failed frame number: %s "%(tcount-icount))
-    dlog.info("total frame number: %s "%tcount)
+
+    rfail=float(tcount - icount)/float(tcount)
+    dlog.info("failed frame: %6d in %6d  %6.2f %% " % (tcount - icount, tcount, rfail * 100.))
+
+    if rfail>ratio_failed:
+       raise RuntimeError("find too many unsuccessfully terminated jobs. Too many FP tasks are not converged. Please check your files in directories \'iter.*.*/02.fp/task.*.*/.\'")
 
 
 def post_fp_pwmat (iter_index,


### PR DESCRIPTION
1. ratio_failed was not applied in post_fp_cp2k.
2. When a cp2k task fails, it returns an empty "output" file. Since dpdispatcher only checks whether the output file exists or not, it marks the task finished and sends back the empty file. An empty or not converged output file leads to errors in the following step. Commenting out check_type_map is a temporary solution, which can run the next step by ignoring empty output files. To solve this problem fundamentally, dpdispatcher should probably be modified as well. 

- add ratio_failed param to cp2k in 02.fp step
- fix a bug in `post_fp_cp2k`