### PR TITLE
remove `train_param` from examples, which was deprecated in #68

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,6 @@ In `PARAM`, you can specialize the task as you expect.
  
   "_comment": " that's all ",
   "numb_models": 4,
-  "train_param": "input.json",
   "default_training_param": {
      "model": {
             "type_map": [
@@ -1015,7 +1014,6 @@ Here is an example of `param.json` for QM7 dataset:
         "auto"
     ],
     "numb_models": 4,
-    "train_param": "input.json",
     "default_training_param": {
         "model": {
             "type_map": [

--- a/doc/run/example-of-param.md
+++ b/doc/run/example-of-param.md
@@ -50,7 +50,6 @@ The training related keys in param.json are given as follows
 
 ```json
   "numb_models": 4,
-  "train_param": "input.json",
   "default_training_param": {
   },
 ```

--- a/dpgen/generator/ch4/param.json
+++ b/dpgen/generator/ch4/param.json
@@ -24,7 +24,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/examples/run/deprecated/dp0.12-lammps-cp2k/CH4/param_CH4.json
+++ b/examples/run/deprecated/dp0.12-lammps-cp2k/CH4/param_CH4.json
@@ -30,7 +30,6 @@
     ], 
     "_comment": " that's all ", 
     "numb_models": 4, 
-    "train_param": "input.json", 
     "default_training_param": {
         "_comment": "that's all", 
         "use_smooth": true, 

--- a/examples/run/deprecated/param-h2oscan-vasp.json
+++ b/examples/run/deprecated/param-h2oscan-vasp.json
@@ -107,7 +107,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/examples/run/deprecated/param-mg-vasp-ucloud.json
+++ b/examples/run/deprecated/param-mg-vasp-ucloud.json
@@ -55,7 +55,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/examples/run/deprecated/param-mg-vasp.json
+++ b/examples/run/deprecated/param-mg-vasp.json
@@ -55,7 +55,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/examples/run/deprecated/param-pyridine-pwscf.json
+++ b/examples/run/deprecated/param-pyridine-pwscf.json
@@ -25,7 +25,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/examples/run/dp1.x_lammps_gaussian/dodecane/dodecane.json
+++ b/examples/run/dp1.x_lammps_gaussian/dodecane/dodecane.json
@@ -9,7 +9,6 @@
     ],
 	  "sys_format":"lammps/lmp",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
       "model":{
         "type_map": ["C","H"],

--- a/examples/simplify/qm7.json
+++ b/examples/simplify/qm7.json
@@ -20,7 +20,6 @@
         "auto"
     ],
     "numb_models": 4,
-    "train_param": "input.json",
     "default_training_param": {
         "model": {
             "type_map": [

--- a/tests/generator/param-mg-vasp-diy.json
+++ b/tests/generator/param-mg-vasp-diy.json
@@ -17,7 +17,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/tests/generator/param-mg-vasp-old.json
+++ b/tests/generator/param-mg-vasp-old.json
@@ -17,7 +17,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/tests/generator/param-mg-vasp.json
+++ b/tests/generator/param-mg-vasp.json
@@ -17,7 +17,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/tests/generator/param-mgo-cp2k-exinput.json
+++ b/tests/generator/param-mgo-cp2k-exinput.json
@@ -25,7 +25,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/tests/generator/param-pyridine-cp2k.json
+++ b/tests/generator/param-pyridine-cp2k.json
@@ -25,7 +25,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/tests/generator/param-pyridine-gaussian.json
+++ b/tests/generator/param-pyridine-gaussian.json
@@ -25,7 +25,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/tests/generator/param-pyridine-pwmat.json
+++ b/tests/generator/param-pyridine-pwmat.json
@@ -25,7 +25,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/tests/generator/param-pyridine-pwscf-old.json
+++ b/tests/generator/param-pyridine-pwscf-old.json
@@ -25,7 +25,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/tests/generator/param-pyridine-pwscf.json
+++ b/tests/generator/param-pyridine-pwscf.json
@@ -25,7 +25,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,

--- a/tests/generator/param-pyridine-siesta.json
+++ b/tests/generator/param-pyridine-siesta.json
@@ -25,7 +25,6 @@
 
     "_comment":		" 00.train ",
     "numb_models":	4,
-    "train_param":	"input.json",
     "default_training_param" : {
 	"_comment": " model parameters",
 	"use_smooth":		true,


### PR DESCRIPTION
See also #68