### PR TITLE
fix post_fp_vasp and make_fp_configs for simplify

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3119,8 +3119,7 @@ def post_fp_vasp (iter_index,
         sys_outcars = glob.glob(os.path.join(work_path, "task.%s.*/OUTCAR"%ss))
         sys_outcars.sort()
         tcount += len(sys_outcars)
-        type_map = jdata['type_map']
-        all_sys = dpdata.MultiSystems(type_map = type_map)
+        all_sys = None
         all_te = []
         for oo in sys_outcars :
             try:
@@ -3133,7 +3132,10 @@ def post_fp_vasp (iter_index,
                    _sys = dpdata.LabeledSystem()
                    dlog.info('Failed fp path: %s'%oo.replace('OUTCAR',''))
             if len(_sys) == 1:
-                all_sys.append(_sys)
+                if all_sys is None:
+                    all_sys = _sys
+                else:
+                    all_sys.append(_sys)
                 # save ele_temp, if any
                 if(os.path.exists(oo.replace('OUTCAR', 'job.json')) ): 
                     with open(oo.replace('OUTCAR', 'job.json')) as fp:
@@ -3150,8 +3152,8 @@ def post_fp_vasp (iter_index,
            all_sys.to_deepmd_raw(sys_data_path)
            all_sys.to_deepmd_npy(sys_data_path, set_size = len(sys_outcars))
            if all_te.size > 0:
-               # assert(len(all_sys) == all_sys.get_nframes())
-               # assert(len(all_sys) == all_te.size)
+               assert(len(all_sys) == all_sys.get_nframes())
+               assert(len(all_sys) == all_te.size)
                all_te = np.reshape(all_te, [-1,1])
                if use_ele_temp == 0:
                    raise RuntimeError('should not get ele temp at setting: use_ele_temp == 0')

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3137,12 +3137,13 @@ def post_fp_vasp (iter_index,
                 else:
                     all_sys.append(_sys)
                 # save ele_temp, if any
-                with open(oo.replace('OUTCAR', 'job.json')) as fp:
-                    job_data = json.load(fp)
-                if 'ele_temp' in job_data:
-                    assert(use_ele_temp)
-                    ele_temp = job_data['ele_temp']
-                    all_te.append(ele_temp)
+                if(os.path.exists(oo.replace('OUTCAR', 'job.json')) ): 
+                    with open(oo.replace('OUTCAR', 'job.json')) as fp:
+                        job_data = json.load(fp)
+                    if 'ele_temp' in job_data:
+                        assert(use_ele_temp)
+                        ele_temp = job_data['ele_temp']
+                        all_te.append(ele_temp)
             else:
                 icount+=1
         all_te = np.array(all_te)

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3119,7 +3119,8 @@ def post_fp_vasp (iter_index,
         sys_outcars = glob.glob(os.path.join(work_path, "task.%s.*/OUTCAR"%ss))
         sys_outcars.sort()
         tcount += len(sys_outcars)
-        all_sys = dpdata.MultiSystems(type_map = jdata['type_map'])
+        type_map = jdata['type_map']
+        all_sys = dpdata.MultiSystems(type_map = type_map)
         all_te = []
         for oo in sys_outcars :
             try:
@@ -3132,10 +3133,7 @@ def post_fp_vasp (iter_index,
                    _sys = dpdata.LabeledSystem()
                    dlog.info('Failed fp path: %s'%oo.replace('OUTCAR',''))
             if len(_sys) == 1:
-                if all_sys is None:
-                    all_sys = _sys
-                else:
-                    all_sys.append(_sys)
+                all_sys.append(_sys)
                 # save ele_temp, if any
                 if(os.path.exists(oo.replace('OUTCAR', 'job.json')) ): 
                     with open(oo.replace('OUTCAR', 'job.json')) as fp:
@@ -3152,8 +3150,8 @@ def post_fp_vasp (iter_index,
            all_sys.to_deepmd_raw(sys_data_path)
            all_sys.to_deepmd_npy(sys_data_path, set_size = len(sys_outcars))
            if all_te.size > 0:
-               assert(len(all_sys) == all_sys.get_nframes())
-               assert(len(all_sys) == all_te.size)
+               # assert(len(all_sys) == all_sys.get_nframes())
+               # assert(len(all_sys) == all_te.size)
                all_te = np.reshape(all_te, [-1,1])
                if use_ele_temp == 0:
                    raise RuntimeError('should not get ele temp at setting: use_ele_temp == 0')

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3119,7 +3119,7 @@ def post_fp_vasp (iter_index,
         sys_outcars = glob.glob(os.path.join(work_path, "task.%s.*/OUTCAR"%ss))
         sys_outcars.sort()
         tcount += len(sys_outcars)
-        all_sys = None
+        all_sys = dpdata.MultiSystems(type_map = jdata['type_map'])
         all_te = []
         for oo in sys_outcars :
             try:

--- a/dpgen/simplify/simplify.py
+++ b/dpgen/simplify/simplify.py
@@ -315,14 +315,16 @@ def make_fp_configs(iter_index, jdata):
     create_path(work_path)
     picked_data_path = os.path.join(iter_name, model_devi_name, picked_data_name)
     systems = get_multi_system(picked_data_path, jdata)
+    ii = 0
     jj = 0
     for system in systems:
         for subsys in system:
-            task_name = "task." + fp_task_fmt % (0, jj)
+            task_name = "task." + fp_task_fmt % (ii, jj)
             task_path = os.path.join(work_path, task_name)
             create_path(task_path)
             subsys.to('vasp/poscar', os.path.join(task_path, 'POSCAR'))
             jj += 1
+        ii += 1
 
 
 def make_fp_gaussian(iter_index, jdata):


### PR DESCRIPTION
When `job.json` is empty, it won't be generated. But post_fp_vasp will call it without checking if it exists. see [https://github.com/deepmodeling/dpgen/issues/794](issue #794)
Besides, there's something wrong with naming task directories. dpdata has to append all different systems into one set, which causes `RuntimeError('systems with inconsistent formula could not be append: %s v.s. %s' % (self.uniq_formula, system.uniq_formula))`. Now those problems are fixed.