### PR TITLE
removed `model_devi_e_trust_lo` and `model_devi_e_trust_hi`, which have been removed in #79

### DIFF
--- a/dpgen/generator/ch4/param.json
+++ b/dpgen/generator/ch4/param.json
@@ -78,8 +78,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.05,
     "model_devi_f_trust_hi":	0.15,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	true,
     "model_devi_jobs":	[
 	{"sys_idx": [0],

--- a/examples/run/deprecated/dp0.12-lammps-pwmat/param_CH4.json
+++ b/examples/run/deprecated/dp0.12-lammps-pwmat/param_CH4.json
@@ -77,8 +77,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.05,
     "model_devi_f_trust_hi":	0.15,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	true,
     "model_devi_jobs":	[
 	{"sys_idx": [0],

--- a/examples/run/deprecated/dp0.12-lammps-vasp/Al/param_al_all_gpu.json
+++ b/examples/run/deprecated/dp0.12-lammps-vasp/Al/param_al_all_gpu.json
@@ -131,8 +131,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.05,
     "model_devi_f_trust_hi":	0.20,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	
 [

--- a/examples/run/deprecated/dp0.12-lammps-vasp/CH4/param_CH4.json
+++ b/examples/run/deprecated/dp0.12-lammps-vasp/CH4/param_CH4.json
@@ -77,8 +77,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.05,
     "model_devi_f_trust_hi":	0.15,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	true,
     "model_devi_jobs":	[
 	{"sys_idx": [0],

--- a/examples/run/deprecated/dp1.x-gromacs-gaussian/param.json
+++ b/examples/run/deprecated/dp1.x-gromacs-gaussian/param.json
@@ -126,8 +126,6 @@
   "model_devi_dt": 0.001,
   "model_devi_f_trust_lo": 0.20,
   "model_devi_f_trust_hi": 0.40,
-  "model_devi_e_trust_lo": 1e10,
-  "model_devi_e_trust_hi": 1e10,
   "model_devi_clean_traj": false,
   "model_devi_skip": 0,
   "model_devi_nopbc": true,

--- a/examples/run/deprecated/param-h2oscan-vasp.json
+++ b/examples/run/deprecated/param-h2oscan-vasp.json
@@ -163,8 +163,6 @@
     "model_devi_skip":		10,
     "model_devi_f_trust_lo":	0.150,
     "model_devi_f_trust_hi":	0.250,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	true,
     "_comment":     "group 1: 0,1,11,lw; group 2: 2-6,9,12-15; group 3: 7,8,lw; group 4: 10.",
     "model_devi_jobs":	[

--- a/examples/run/deprecated/param-mg-vasp-ucloud.json
+++ b/examples/run/deprecated/param-mg-vasp-ucloud.json
@@ -109,8 +109,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.050,
     "model_devi_f_trust_hi":	0.150,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	true,
 
     "model_devi_jobs":	[

--- a/examples/run/deprecated/param-mg-vasp.json
+++ b/examples/run/deprecated/param-mg-vasp.json
@@ -109,8 +109,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.050,
     "model_devi_f_trust_hi":	0.150,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	true,
     "model_devi_jobs":	[
 	{"sys_idx": [0,4,26,30], "temps": [  50], "press": [1.0], "trj_freq": 10, "nsteps": 1000, "ensemble": "nvt", "_idx": "00"},

--- a/examples/run/deprecated/param-pyridine-pwscf.json
+++ b/examples/run/deprecated/param-pyridine-pwscf.json
@@ -79,8 +79,6 @@
     "model_devi_skip":		10,
     "model_devi_f_trust_lo":	0.200,
     "model_devi_f_trust_hi":	0.300,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	true,
     "model_devi_jobs":	[
 	{"sys_idx": [0,4], "temps": [  50], "press": [1e0,1e1,1e2,1e3,1e4,2e4,4e4], "trj_freq": 10, "nsteps": 1000, "ensemble": "npt", "_idx": "00"},

--- a/examples/run/dp1.x-lammps-ABACUS-lcao-dpks/methane/param.json
+++ b/examples/run/dp1.x-lammps-ABACUS-lcao-dpks/methane/param.json
@@ -88,8 +88,6 @@
   "model_devi_skip": 0,
   "model_devi_f_trust_lo":  0.05,
   "model_devi_f_trust_hi":  0.15,
-  "model_devi_e_trust_lo": 1e-3,
-  "model_devi_e_trust_hi": 1e-1,
   "model_devi_clean_traj":  false,
   "model_devi_jobs": [
     {

--- a/examples/run/dp1.x-lammps-vasp-et/param_elet.json
+++ b/examples/run/dp1.x-lammps-vasp-et/param_elet.json
@@ -83,8 +83,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.05,
     "model_devi_f_trust_hi":	0.20,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{ "_idx": 0, "ensemble": "npt", "nsteps": 50, "press": [1.0,2.0], "sys_idx": [0, 1], "temps": [50,100], "trj_freq": 10 }

--- a/examples/run/dp1.x-lammps-vasp/Al/param_al_all_gpu-deepmd-kit-1.1.0.json
+++ b/examples/run/dp1.x-lammps-vasp/Al/param_al_all_gpu-deepmd-kit-1.1.0.json
@@ -109,8 +109,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.05,
     "model_devi_f_trust_hi":	0.20,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	
 [

--- a/examples/run/dp1.x-lammps-vasp/CH4/param_CH4_deepmd-kit-1.1.0.json
+++ b/examples/run/dp1.x-lammps-vasp/CH4/param_CH4_deepmd-kit-1.1.0.json
@@ -90,8 +90,6 @@
     "model_devi_skip": 0,
     "model_devi_f_trust_lo": 0.05,
     "model_devi_f_trust_hi": 0.15,
-    "model_devi_e_trust_lo": 10000000000.0,
-    "model_devi_e_trust_hi": 10000000000.0,
     "model_devi_clean_traj": true,
     "model_devi_jobs": [
         {

--- a/examples/run/dp1.x_lammps_gaussian/dodecane/dodecane.json
+++ b/examples/run/dp1.x_lammps_gaussian/dodecane/dodecane.json
@@ -67,8 +67,6 @@
     "model_devi_skip":		100,
     "model_devi_f_trust_lo":	0.20,
     "model_devi_f_trust_hi":	0.45,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
       {"sys_idx": [0], "temps": [  3000], "trj_freq": 10, "nsteps": 2000, "ensemble": "nvt", "_idx": "00"},

--- a/examples/run/dp2.x-gromacs-gaussian/param.json
+++ b/examples/run/dp2.x-gromacs-gaussian/param.json
@@ -122,8 +122,6 @@
   "model_devi_dt": 0.001,
   "model_devi_f_trust_lo": 0.20,
   "model_devi_f_trust_hi": 0.60,
-  "model_devi_e_trust_lo": 1e10,
-  "model_devi_e_trust_hi": 1e10,
   "model_devi_clean_traj": false,
   "model_devi_skip": 0,
   "model_devi_nopbc": true,

--- a/examples/run/dp2.x-lammps-vasp/param_CH4_deepmd-kit-2.0.1.json
+++ b/examples/run/dp2.x-lammps-vasp/param_CH4_deepmd-kit-2.0.1.json
@@ -88,8 +88,6 @@
     "model_devi_skip": 0,
     "model_devi_f_trust_lo": 0.05,
     "model_devi_f_trust_hi": 0.15,
-    "model_devi_e_trust_lo": 10000000000.0,
-    "model_devi_e_trust_hi": 10000000000.0,
     "model_devi_clean_traj": true,
     "model_devi_jobs": [
         {

--- a/tests/generator/param-mg-vasp-diy.json
+++ b/tests/generator/param-mg-vasp-diy.json
@@ -71,8 +71,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.050,
     "model_devi_f_trust_hi":	0.150,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{"sys_idx": [0,1], "temps": [50,100], "press": [1.0,2.0], "trj_freq": 10, "nsteps": 1000, "ensemble": "npt", "_idx": "00"}

--- a/tests/generator/param-mg-vasp-old.json
+++ b/tests/generator/param-mg-vasp-old.json
@@ -71,8 +71,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.050,
     "model_devi_f_trust_hi":	0.150,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{"sys_idx": [0,1], "temps": [50,100], "press": [1.0,2.0], "trj_freq": 10, "nsteps": 1000, "ensemble": "npt", "_idx": "00"}

--- a/tests/generator/param-mg-vasp-v1-et.json
+++ b/tests/generator/param-mg-vasp-v1-et.json
@@ -79,8 +79,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.05,
     "model_devi_f_trust_hi":	0.20,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{ "_idx": 0, "ensemble": "npt", "nsteps": 50, "press": [1.0,2.0], "sys_idx": [0, 1], "temps": [50,100], "trj_freq": 10 }

--- a/tests/generator/param-mg-vasp-v1.json
+++ b/tests/generator/param-mg-vasp-v1.json
@@ -78,8 +78,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.05,
     "model_devi_f_trust_hi":	0.20,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{ "_idx": 0, "ensemble": "npt", "nsteps": 50, "press": [1.0,2.0], "sys_idx": [0, 1], "temps": [50,100], "trj_freq": 10 }

--- a/tests/generator/param-mg-vasp.json
+++ b/tests/generator/param-mg-vasp.json
@@ -71,8 +71,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.050,
     "model_devi_f_trust_hi":	0.150,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{"sys_idx": [0,1], "temps": [50,100], "press": [1.0,2.0], "trj_freq": 10, "nsteps": 1000, "ensemble": "npt", "_idx": "00"}

--- a/tests/generator/param-mgo-cp2k-exinput.json
+++ b/tests/generator/param-mgo-cp2k-exinput.json
@@ -79,8 +79,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.050,
     "model_devi_f_trust_hi":	0.150,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{"sys_idx": [0,4], "temps": [  50], "press": [1e0,1e1,1e2,1e3,1e4,2e4,4e4], "trj_freq": 10, "nsteps": 1000, "ensemble": "npt", "_idx": "00"},

--- a/tests/generator/param-pyridine-cp2k.json
+++ b/tests/generator/param-pyridine-cp2k.json
@@ -79,8 +79,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.050,
     "model_devi_f_trust_hi":	0.150,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{"sys_idx": [0,4], "temps": [  50], "press": [1e0,1e1,1e2,1e3,1e4,2e4,4e4], "trj_freq": 10, "nsteps": 1000, "ensemble": "npt", "_idx": "00"},

--- a/tests/generator/param-pyridine-gaussian.json
+++ b/tests/generator/param-pyridine-gaussian.json
@@ -79,8 +79,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.050,
     "model_devi_f_trust_hi":	0.150,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{"sys_idx": [0,4], "temps": [  50], "press": [1e0,1e1,1e2,1e3,1e4,2e4,4e4], "trj_freq": 10, "nsteps": 1000, "ensemble": "npt", "_idx": "00"},

--- a/tests/generator/param-pyridine-pwmat.json
+++ b/tests/generator/param-pyridine-pwmat.json
@@ -79,8 +79,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.050,
     "model_devi_f_trust_hi":	0.150,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{"sys_idx": [0,4], "temps": [  50], "press": [1e0,1e1,1e2,1e3,1e4,2e4,4e4], "trj_freq": 10, "nsteps": 1000, "ensemble": "npt", "_idx": "00"},

--- a/tests/generator/param-pyridine-pwscf-old.json
+++ b/tests/generator/param-pyridine-pwscf-old.json
@@ -79,8 +79,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.050,
     "model_devi_f_trust_hi":	0.150,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{"sys_idx": [0,4], "temps": [  50], "press": [1e0,1e1,1e2,1e3,1e4,2e4,4e4], "trj_freq": 10, "nsteps": 1000, "ensemble": "npt", "_idx": "00"},

--- a/tests/generator/param-pyridine-pwscf.json
+++ b/tests/generator/param-pyridine-pwscf.json
@@ -79,8 +79,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.050,
     "model_devi_f_trust_hi":	0.150,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{"sys_idx": [0,4], "temps": [  50], "press": [1e0,1e1,1e2,1e3,1e4,2e4,4e4], "trj_freq": 10, "nsteps": 1000, "ensemble": "npt", "_idx": "00"},

--- a/tests/generator/param-pyridine-siesta.json
+++ b/tests/generator/param-pyridine-siesta.json
@@ -79,8 +79,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.050,
     "model_devi_f_trust_hi":	0.150,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{"sys_idx": [0,4], "temps": [  50], "press": [1e0,1e1,1e2,1e3,1e4,2e4,4e4], "trj_freq": 10, "nsteps": 1000, "ensemble": "npt", "_idx": "00"},

--- a/tests/generator/test_gromacs_engine.py
+++ b/tests/generator/test_gromacs_engine.py
@@ -40,8 +40,6 @@ class TestGromacsModelDeviEngine(unittest.TestCase):
             "model_devi_dt":         0.001,
             "model_devi_f_trust_lo": 0.05,
             "model_devi_f_trust_hi": 0.10,
-            "model_devi_e_trust_lo": 1e10,
-            "model_devi_e_trust_hi": 1e10,
             "model_devi_clean_traj": False,
             "model_devi_skip":       0,
             "model_devi_nopbc":      True,

--- a/tests/generator/test_make_md.py
+++ b/tests/generator/test_make_md.py
@@ -206,8 +206,6 @@ class TestMakeModelDeviRevMat(unittest.TestCase):
             "shuffle_poscar":	False,
             "model_devi_f_trust_lo":	0.050,
             "model_devi_f_trust_hi":	0.150,
-            "model_devi_e_trust_lo":	1e10,
-            "model_devi_e_trust_hi":	1e10,
             "model_devi_plumed":        True,
             "model_devi_jobs":	[
                 {"sys_idx": [0, 1], 'traj_freq': 10, "template": {"lmp": "lmp/input.lammps", "plm": "lmp/input.plumed"},
@@ -323,8 +321,6 @@ class TestMakeModelDeviRevMat(unittest.TestCase):
             "shuffle_poscar":	False,
             "model_devi_f_trust_lo":	0.050,
             "model_devi_f_trust_hi":	0.150,
-            "model_devi_e_trust_lo":	1e10,
-            "model_devi_e_trust_hi":	1e10,
             "model_devi_plumed":        True,
             "model_devi_jobs":	[
                 {"sys_idx": [0, 1], 'traj_freq': 10,  "template":{"lmp": "lmp/input.lammps", "plm": "lmp/input.plumed"},

--- a/tests/tools/run_report_test_output/param.json
+++ b/tests/tools/run_report_test_output/param.json
@@ -70,8 +70,6 @@
     "model_devi_skip":		0,
     "model_devi_f_trust_lo":	0.05,
     "model_devi_f_trust_hi":	0.20,
-    "model_devi_e_trust_lo":	1e10,
-    "model_devi_e_trust_hi":	1e10,
     "model_devi_clean_traj":	false,
     "model_devi_jobs":	[
 	{ "_idx": 0, "ensemble": "npt", "nsteps": 50, "press": [1.0,2.0], "sys_idx": [0, 1], "temps": [50,100], "trj_freq": 10 }


### PR DESCRIPTION
See also #79