### PR TITLE
args: remove duplicated argument

### DIFF
--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -159,7 +159,6 @@ The union of the two sets is made as candidate dataset.'
     doc_model_devi_f_avg_relative = 'Normalized the force model deviations by the RMS force magnitude along the trajectory. This key should not be used with use_relative.'
     doc_model_devi_clean_traj = 'If type of model_devi_clean_traj is bool type then it denote whether to clean traj folders in MD since they are too large. If it is Int type, then the most recent n iterations of traj folders will be retained, others will be removed.'
     doc_model_devi_nopbc = 'Assume open boundary condition in MD simulations.'
-    doc_model_devi_activation_func = 'Set activation functions for models, length of the list should be the same as numb_models, and two elements in the list of string respectively assign activation functions to the embedding and fitting nets within each model. Backward compatibility: the orginal "list of String" format is still supported, where embedding and fitting nets of one model use the same activation function, and the length of the list should be the same as numb_models.'
     doc_shuffle_poscar = 'Shuffle atoms of each frame before running simulations. The purpose is to sample the element occupation of alloys.'
     doc_use_relative = 'Calculate relative force model deviation.'
     doc_epsilon = 'The level parameter for computing the relative force model deviation.'
@@ -196,8 +195,6 @@ The union of the two sets is made as candidate dataset.'
                  bool, int], optional=False, doc=doc_model_devi_clean_traj),
         Argument("model_devi_nopbc", bool, optional=True, default=False,
                  doc=doc_model_devi_nopbc),
-        Argument("model_devi_activation_func", list, optional=True,
-                 doc=doc_model_devi_activation_func),
         Argument("shuffle_poscar", bool, optional=True, default=False, doc=doc_shuffle_poscar),
         Argument("use_relative", bool, optional=True, default=False, doc=doc_use_relative),
         Argument("epsilon", float, optional=True, doc=doc_epsilon),


### PR DESCRIPTION
I don't notice it's duplicated in #829 but the unit test in #821 has thrown errors.