### PR TITLE
refactor: delete relax_kspacing and md_kspacing in abacus init step

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you want to specify a structure as starting point for `init_bulk`, you may se
 ```
 `init_bulk` support both VASP and ABACUS for first-principle calculation. You can choose the software by specifying the key `init_fp_style`. If `init_fp_style` is not specified, the default software will be VASP. 
 
-When using ABACUS for `init_fp_style`, the keys of the paths of `INPUT` files for relaxation and MD simulations are the same as `INCAR` for VASP, which are `relax_incar` and `md_incar` respectively. You have to additionally specify `relax_kspacing` and `md_kspacing` for k points spacing, and dpgen will automatically generate `KPT` files according to them. You may also use `relax_kpt` and `md_kpt` instead of them for the relative path for `KPT` files of relaxation and MD simulations. However, either `relax_kspacing` and `md_kspacing`, or `relax_kpt` and `md_kpt` is needed. If `from_poscar` is set to `false`, you have to specify `atom_masses` in the same order as `elements`.
+When using ABACUS for `init_fp_style`, the keys of the paths of `INPUT` files for relaxation and MD simulations are the same as `INCAR` for VASP, which are `relax_incar` and `md_incar` respectively. Use `relax_kpt` and `md_kpt` for the relative path for `KPT` files of relaxation and MD simulations. They two can be ommited if `kspacing` or `gamma_only` has been set in corresponding INPUT files. If `from_poscar` is set to `false`, you have to specify `atom_masses` in the same order as `elements`.
 
 The following table gives explicit descriptions on keys in `PARAM`.
 

--- a/dpgen/data/gen.py
+++ b/dpgen/data/gen.py
@@ -380,12 +380,6 @@ def make_super_cell_STRU(jdata) :
     stru_text = make_abacus_scf_stru(from_struct, pp_file_names, orb_file_names, dpks_descriptor_name)
     with open(to_file, "w") as fp:
         fp.write(stru_text) 
-    # if kspacing is specified in json file, use kspacing to generate KPT (rather than directly using specified KPT).
-    if 'relax_kspacing' in jdata:
-        kpoints = make_kspacing_kpoints_stru(from_struct, jdata['relax_kspacing'])
-        kpt_text = make_abacus_scf_kpt({"k_points": kpoints})
-        with open(os.path.join(to_path, 'KPT'), "w") as fp:
-            fp.write(kpt_text)
     # make system dir (copy)
     natoms_list = from_struct['atom_numbs']
     dlog.info(natoms_list)
@@ -469,12 +463,6 @@ def place_element_ABACUS(jdata, supercell_stru):
     #path_sc = os.path.join(out_dir, global_dirname_02)
     path_pe = os.path.join(out_dir, global_dirname_02)    
     combines = np.array(make_combines(len(elements), natoms), dtype = int)
-    # if kspacing is specified in json file, use kspacing to generate KPT (rather than directly using specified KPT).
-    if 'relax_kspacing' in jdata:
-        kpoints = make_kspacing_kpoints_stru(supercell_stru)
-        kpt_text = make_abacus_scf_kpt({"k_points": kpoints})
-        with open(os.path.join(path_pe, 'KPT')) as fp:
-            fp.write(kpt_text)
     assert(os.path.isdir(path_pe))
     cwd = os.getcwd()
     for ii in combines :
@@ -555,6 +543,9 @@ def make_abacus_relax (jdata, mdata) :
                 else:
                     md_kpt_path = jdata['relax_kpt']
                     assert(os.path.isfile(relax_kpt_path)), "file %s should exists" % relax_kpt_path
+            else:
+                gamma_param = {"k_points":[1,1,1,0,0,0]}
+                ret_kpt = make_abacus_scf_kpt(gamma_param)
         else:
             if "relax_kpt" not in jdata:
                 raise RuntimeError("Cannot find any k-points information.")
@@ -572,13 +563,17 @@ def make_abacus_relax (jdata, mdata) :
         os.remove(os.path.join(work_dir, 'INPUT' ))
     shutil.copy2( jdata['relax_incar'], 
                  os.path.join(work_dir, 'INPUT'))
+
     
-    if not (("kspacing" in standard_incar) or \
-            ("gamma_only" in standard_incar and standard_incar["gamma_only"]==1)):
+    if "kspacing" not in standard_incar:
         if os.path.isfile(os.path.join(work_dir, 'KPT' )) :
             os.remove(os.path.join(work_dir, 'KPT' ))
-        jdata['relax_kpt'] = os.path.relpath(jdata['relax_kpt'])
-        shutil.copy2(jdata['relax_kpt'],os.path.join(work_dir, 'KPT'))
+        if "gamma_only" in standard_incar and standard_incar["gamma_only"]==1:
+            with open(os.path.join(work_dir,'KPT'),"w") as fp:
+                fp.write(ret_kpt)
+        else:
+            jdata['relax_kpt'] = os.path.relpath(jdata['relax_kpt'])
+            shutil.copy2(jdata['relax_kpt'],os.path.join(work_dir, 'KPT'))
     
     if "dpks_model" in jdata:
         dpks_model_absolute_path = os.path.abspath(jdata["dpks_model"])
@@ -593,16 +588,18 @@ def make_abacus_relax (jdata, mdata) :
     for ss in sys_list:
         os.chdir(ss)
         ln_src = os.path.relpath(os.path.join(work_dir,'INPUT'))
-        kpt_src = os.path.relpath(os.path.join(work_dir,'KPT'))
+        if "kspacing" not in standard_incar:
+            kpt_src = os.path.relpath(os.path.join(work_dir,'KPT'))
         if "dpks_model" in jdata:
             ksmd_src = os.path.relpath(os.path.join(work_dir,dpks_model_name))
         try:
-           os.symlink(ln_src, 'INPUT')
-           os.symlink(kpt_src, 'KPT')
-           if "dpks_model" in jdata:
-               os.symlink(ksmd_src, dpks_model_name)
+            os.symlink(ln_src, 'INPUT')
+            if "kspacing" not in standard_incar:
+                os.symlink(kpt_src, 'KPT')
+            if "dpks_model" in jdata:
+                os.symlink(ksmd_src, dpks_model_name)
         except FileExistsError:
-           pass
+            pass
         os.chdir(work_dir)
     os.chdir(cwd)
     symlink_user_forward_files(mdata=mdata, task_type="fp",
@@ -850,6 +847,8 @@ def make_abacus_md(jdata, mdata) :
                 else:
                     md_kpt_path = jdata['md_kpt']
                     assert(os.path.isfile(md_kpt_path)), "file %s should exists" % md_kpt_path
+            else:
+                ret_kpt = make_abacus_scf_kpt({"k_points":[1,1,1,0,0,0]})
         else:
             if "md_kpt" not in jdata:
                 raise RuntimeError("Cannot find any k-points information.")
@@ -876,9 +875,12 @@ def make_abacus_md(jdata, mdata) :
     create_path(path_md)
     shutil.copy2(jdata['md_incar'], 
                  os.path.join(path_md, 'INPUT'))
-    if not (("kspacing" in standard_incar) or \
-            ("gamma_only" in standard_incar and standard_incar["gamma_only"]==1)):
-        shutil.copy2(jdata['md_kpt'],os.path.join(path_md, 'KPT'))
+    if "kspacing" not in standard_incar:
+        if "gamma_only" in standard_incar and standard_incar["gamma_only"]==1:
+            with open(os.path.join(path_md,"KPT"),"w") as fp:
+                fp.write(ret_kpt)
+        else:
+            shutil.copy2(jdata['md_kpt'],os.path.join(path_md, 'KPT'))
     orb_file_names = None
     orb_file_abspath = None
     dpks_descriptor_name = None
@@ -923,18 +925,14 @@ def make_abacus_md(jdata, mdata) :
                 path_pos = os.path.join(path_pos, "scale-%.3f" % jj)
                 path_pos = os.path.join(path_pos, "%06d" % kk)
                 init_pos = os.path.join(path_pos, 'STRU')
-                if "md_kspacing" in jdata:
-                    init_stru = get_abacus_STRU(init_pos)
-                    kpoints = make_kspacing_kpoints_stru(init_stru, jdata['md_kspacing'])
-                    kpt_text = make_abacus_scf_kpt({"k_points": kpoints})
-                    with open(os.path.join(path_md, 'KPT'), "w") as fp:
-                        fp.write(kpt_text)
+                if "kspacing" not in standard_incar:
+                    file_kpt = os.path.join(path_md, 'KPT')
                 shutil.copy2 (init_pos, 'STRU')
                 file_incar = os.path.join(path_md, 'INPUT')
-                file_kpt = os.path.join(path_md, 'KPT')
                 try:
                     os.symlink(os.path.relpath(file_incar), 'INPUT')
-                    os.symlink(os.path.relpath(file_kpt), 'KPT')
+                    if "kspacing" not in standard_incar:
+                        os.symlink(os.path.relpath(file_kpt), 'KPT')
                 except FileExistsError:
                     pass
                 try:
@@ -1181,10 +1179,10 @@ def run_abacus_relax(jdata, mdata):
         dpks_descriptor_name = [os.path.basename(jdata['dpks_descriptor'])]
     if 'dpks_model' in jdata:
         dpks_model_name = [os.path.basename(jdata['dpks_model'])]
-    forward_files = ["STRU", "INPUT"] + orb_file_names + dpks_descriptor_name + dpks_model_name
-    if not (("kspacing" in standard_incar) or \
-            ("gamma_only" in standard_incar and standard_incar["gamma_only"]==1)):
-        forward_files = ["STRU", "INPUT", "KPT"] + orb_file_names + dpks_descriptor_name + dpks_model_name
+    forward_files = ["STRU", "INPUT"]
+    if "kspacing" not in standard_incar:
+        forward_files = ["STRU", "INPUT", "KPT"]
+    forward_files += pp_files + orb_file_names + dpks_descriptor_name + dpks_model_name
     user_forward_files = mdata.get("fp" + "_user_forward_files", [])
     forward_files += [os.path.basename(file) for file in user_forward_files]
     backward_files = ["OUT.ABACUS"]
@@ -1323,10 +1321,11 @@ def run_abacus_md(jdata, mdata):
         dpks_descriptor_name = [os.path.basename(jdata['dpks_descriptor'])]
     if 'dpks_model' in jdata:
         dpks_model_name = [os.path.basename(jdata['dpks_model'])]
-    forward_files = ["STRU", "INPUT"] + orb_file_names + dpks_descriptor_name + dpks_model_name
+    forward_files = ["STRU", "INPUT"]
     if not (("kspacing" in standard_incar) or \
             ("gamma_only" in standard_incar and standard_incar["gamma_only"]==1)):
-        forward_files = ["STRU", "INPUT", "KPT"] + orb_file_names + dpks_descriptor_name + dpks_model_name
+        forward_files = ["STRU", "INPUT", "KPT"]
+    forward_files += orb_file_names + dpks_descriptor_name + dpks_model_name
     for pp_file in [os.path.basename(a) for a in jdata['potcars']]:
         forward_files.append(pp_file)
     user_forward_files = mdata.get("fp" + "_user_forward_files", [])


### PR DESCRIPTION
Delete relax_kspacing and md_kspacing in abacus init step, because kspacing has been added in ABACUS itself. They have different unit (one in 1/Bohr and another in 1/A), and may cause confusions. 