### PR TITLE
Change the location of “export ” in Slurm.py

### DIFF
--- a/dpgen/dispatcher/Slurm.py
+++ b/dpgen/dispatcher/Slurm.py
@@ -106,6 +106,11 @@ class Slurm(Batch) :
         for flag in res.get('custom_flags', []):
             ret += '#SBATCH %s \n' % flag
         ret += "\n"
+        envs = res['envs']
+        if envs != None :
+            for key in envs.keys() :
+                ret += 'export %s=%s\n' % (key, envs[key])
+            ret += '\n' 
         for ii in res['module_unload_list'] :
             ret += "module unload %s\n" % ii
         for ii in res['module_list'] :
@@ -113,12 +118,7 @@ class Slurm(Batch) :
         ret += "\n"
         for ii in res['source_list'] :
             ret += "source %s\n" %ii
-        ret += "\n"
-        envs = res['envs']
-        if envs != None :
-            for key in envs.keys() :
-                ret += 'export %s=%s\n' % (key, envs[key])
-            ret += '\n'        
+        ret += "\n"       
         return ret
 
     def sub_script_cmd(self,


### PR DESCRIPTION
In more cases, shoule the location of "export" be placed in front of "source"?
For example, it applies to the following situations (otherwise my_package cannot be found):

_export PATH="/home_path/anaconda/envs/my_package/bin:$PATH"
source activate my_package_