### PR TITLE
fix: check the number of collected data in `post_fp_check_fail`

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3181,7 +3181,7 @@ def post_fp_check_fail(iter_index,
     sys_data.sort()
     nframe = 0
     for ii in sys_data :
-        sys = dpdata.LabeledSystem().from_deepmd_raw(ii, type_map = jdata['type_map'])
+        sys = dpdata.LabeledSystem(ii, fmt = 'deepmd/raw')
         nframe += len(sys)
     nfail = ntask - nframe
 

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3165,23 +3165,36 @@ def run_fp (iter_index,
 def post_fp_check_fail(iter_index,
                        jdata,
                        rfailed = None) :
+
     ratio_failed =  rfailed if rfailed else jdata.get('ratio_failed',0.05)
     iter_name = make_iter_name(iter_index)
     work_path = os.path.join(iter_name, fp_name)
-
-    # check fail according to _flag_if_job_task_fail, which will be 1 if any task in the group fails.
-    fp_flags = glob.glob(os.path.join(work_path, '*_flag_if_job_task_fail'))
-    if(len(fp_flags) == 0) :
+    fp_tasks = glob.glob(os.path.join(work_path, 'task.*'))
+    fp_tasks.sort()
+    if len(fp_tasks) == 0 :
         return
-    njob = len(fp_flags)
+    ntask = len(fp_tasks)
     nfail = 0
-    for ii in fp_flags:
-        with open(ii) as fp:
-            fail_flag = fp.read()
-            if fail_flag :
-                nfail += 1
-    rfail = float(nfail) / float(njob)
-    dlog.info("failed jobs: %6d in %6d  %6.2f %% " % (nfail, njob, rfail * 100.))
+
+    api_version = mdata.get('api_version', '0.9')
+    if LooseVersion(api_version) < LooseVersion('1.0') :
+        # check fail according to tag_failure
+        fp_failed_tags = glob.glob(os.path.join(work_path, 'task.*', out_file))
+        fp_failed_tasks = [os.path.dirname(ii) for ii in fp_failed_tags]
+        fp_failed_tasks = list(set(fp_failed_tasks))
+        nfail = len(fp_failed_tasks)
+    elif LooseVersion(api_version) >= LooseVersion('1.0'):
+        # check fail according to the number of collected data
+        sys_data = glob.glob(os.path.join(work_path, "data.*"))
+        sys_data.sort()
+        nframe = 0
+        for ii in sys_data :
+            sys = dpdata.LabeledSystem().from_deepmd_raw(ii, type_map = jdata['type_map'])
+            nframe += len(sys)
+        nfail = ntask - nframe
+
+    rfail = float(nfail) / float(ntask)
+    dlog.info("failed tasks: %6d in %6d  %6.2f %% " % (nfail, ntask, rfail * 100.))
     if rfail > ratio_failed:
        raise RuntimeError("find too many unsuccessfully terminated jobs")
 
@@ -3605,7 +3618,6 @@ def post_fp_amber_diff(iter_index, jdata):
 def post_fp (iter_index,
              jdata) :
     fp_style = jdata['fp_style']
-    post_fp_check_fail(iter_index, jdata)
     if fp_style == "vasp" :
         post_fp_vasp(iter_index, jdata)
     elif fp_style == "pwscf" :
@@ -3624,6 +3636,7 @@ def post_fp (iter_index,
         post_fp_amber_diff(iter_index, jdata)
     else :
         raise RuntimeError ("unsupported fp style")
+    post_fp_check_fail(iter_index, jdata)
     # clean traj
     clean_traj = True
     if 'model_devi_clean_traj' in jdata :

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3184,7 +3184,7 @@ def post_fp_check_fail(iter_index,
         sys_paths = expand_sys_str(ii)
         for single_sys in sys_paths:
             sys = dpdata.LabeledSystem(os.path.join(single_sys), fmt = 'deepmd/npy')
-        nframe += len(sys)
+            nframe += len(sys)
     nfail = ntask - nframe
 
     rfail = float(nfail) / float(ntask)

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3175,15 +3175,14 @@ def post_fp_check_fail(iter_index,
         return
     ntask = len(fp_tasks)
     nfail = 0
+    nsys = 0
 
     # check fail according to the number of collected data
     sys_data = glob.glob(os.path.join(work_path, "data.*"))
-    sys_data.sort()
-    nframe = 0
     for ii in sys_data :
-        sys = dpdata.LabeledSystem(ii, fmt = 'deepmd/npy')
-        nframe += len(sys)
-    nfail = ntask - nframe
+        sys_paths = expand_sys_str(ii)
+        nsys += len(sys_paths)
+    nfail = ntask - nsys
 
     rfail = float(nfail) / float(ntask)
     dlog.info("failed tasks: %6d in %6d  %6.2f %% " % (nfail, ntask, rfail * 100.))

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3176,22 +3176,14 @@ def post_fp_check_fail(iter_index,
     ntask = len(fp_tasks)
     nfail = 0
 
-    api_version = mdata.get('api_version', '0.9')
-    if LooseVersion(api_version) < LooseVersion('1.0') :
-        # check fail according to tag_failure
-        fp_failed_tags = glob.glob(os.path.join(work_path, 'task.*', out_file))
-        fp_failed_tasks = [os.path.dirname(ii) for ii in fp_failed_tags]
-        fp_failed_tasks = list(set(fp_failed_tasks))
-        nfail = len(fp_failed_tasks)
-    elif LooseVersion(api_version) >= LooseVersion('1.0'):
-        # check fail according to the number of collected data
-        sys_data = glob.glob(os.path.join(work_path, "data.*"))
-        sys_data.sort()
-        nframe = 0
-        for ii in sys_data :
-            sys = dpdata.LabeledSystem().from_deepmd_raw(ii, type_map = jdata['type_map'])
-            nframe += len(sys)
-        nfail = ntask - nframe
+    # check fail according to the number of collected data
+    sys_data = glob.glob(os.path.join(work_path, "data.*"))
+    sys_data.sort()
+    nframe = 0
+    for ii in sys_data :
+        sys = dpdata.LabeledSystem().from_deepmd_raw(ii, type_map = jdata['type_map'])
+        nframe += len(sys)
+    nfail = ntask - nframe
 
     rfail = float(nfail) / float(ntask)
     dlog.info("failed tasks: %6d in %6d  %6.2f %% " % (nfail, ntask, rfail * 100.))

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3175,14 +3175,17 @@ def post_fp_check_fail(iter_index,
         return
     ntask = len(fp_tasks)
     nfail = 0
-    nsys = 0
 
     # check fail according to the number of collected data
     sys_data = glob.glob(os.path.join(work_path, "data.*"))
+    sys_data.sort()
+    nframe = 0
     for ii in sys_data :
         sys_paths = expand_sys_str(ii)
-        nsys += len(sys_paths)
-    nfail = ntask - nsys
+        for single_sys in sys_paths:
+            sys = dpdata.LabeledSystem(os.path.join(single_sys), fmt = 'deepmd/npy')
+        nframe += len(sys)
+    nfail = ntask - nframe
 
     rfail = float(nfail) / float(ntask)
     dlog.info("failed tasks: %6d in %6d  %6.2f %% " % (nfail, ntask, rfail * 100.))

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3168,19 +3168,20 @@ def post_fp_check_fail(iter_index,
     ratio_failed =  rfailed if rfailed else jdata.get('ratio_failed',0.05)
     iter_name = make_iter_name(iter_index)
     work_path = os.path.join(iter_name, fp_name)
-    fp_tasks = glob.glob(os.path.join(work_path, 'task.*'))
-    fp_tasks.sort()
-    if len(fp_tasks) == 0 :
-        return
-    # check fail according to tag_failure
-    fp_failed_tags = glob.glob(os.path.join(work_path, 'task.*', 'tag_failure*'))
-    fp_failed_tasks = [os.path.dirname(ii) for ii in fp_failed_tags]
-    fp_failed_tasks = list(set(fp_failed_tasks))
 
-    ntask = len(fp_tasks)
-    nfail = len(fp_failed_tasks)
-    rfail = float(nfail) / float(ntask)
-    dlog.info("failed tasks: %6d in %6d  %6.2f %% " % (nfail, ntask, rfail * 100.))
+    # check fail according to _flag_if_job_task_fail, which will be 1 if any task in the group fails.
+    fp_flags = glob.glob(os.path.join(work_path, '*_flag_if_job_task_fail'))
+    if(len(fp_flags) == 0) :
+        return
+    njob = len(fp_flags)
+    nfail = 0
+    for ii in fp_flags:
+        with open(ii) as fp:
+            fail_flag = fp.read()
+            if fail_flag :
+                nfail += 1
+    rfail = float(nfail) / float(njob)
+    dlog.info("failed tasks: %6d in %6d  %6.2f %% " % (nfail, njob, rfail * 100.))
     if rfail > ratio_failed:
        raise RuntimeError("find too many unsuccessfully terminated jobs")
 

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3181,7 +3181,7 @@ def post_fp_check_fail(iter_index,
             if fail_flag :
                 nfail += 1
     rfail = float(nfail) / float(njob)
-    dlog.info("failed tasks: %6d in %6d  %6.2f %% " % (nfail, njob, rfail * 100.))
+    dlog.info("failed jobs: %6d in %6d  %6.2f %% " % (nfail, njob, rfail * 100.))
     if rfail > ratio_failed:
        raise RuntimeError("find too many unsuccessfully terminated jobs")
 

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3181,7 +3181,7 @@ def post_fp_check_fail(iter_index,
     sys_data.sort()
     nframe = 0
     for ii in sys_data :
-        sys = dpdata.LabeledSystem(ii, fmt = 'deepmd/raw')
+        sys = dpdata.LabeledSystem(ii, fmt = 'deepmd/npy')
         nframe += len(sys)
     nfail = ntask - nframe
 


### PR DESCRIPTION
see #737 
dpdispatcher use flag_if_job_task_fail to mark the failed jobs, so `post_fp_check_fail` can be used before checking the frames. If we use the alternative way the issue mentioned, we should consider different representative outputs according to `fp_style`. I am wondering if it is a repeat of the following frame checks. However, since `flag_if_job_task_fail` will be marked as True if one task in the group is failed, I am afraid that `rfail` could be high when only a few tasks fail. I'd like to ask for some suggestions.