### PR TITLE
Update run.py | Check if outcar exists.

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3218,7 +3218,7 @@ def post_fp_vasp (iter_index,
         sys_outcars = glob.glob(os.path.join(work_path, "task.%s.*/OUTCAR"%ss))
         sys_outcars.sort()
         if len(sys_outcars) == 0:
-                raise RuntimeError("OUTCAR does not exist! please check fp_tasks.")
+            raise RuntimeError("OUTCAR does not exist! please check fp_tasks.")
         tcount += len(sys_outcars)
         all_sys = None
         all_te = []

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -3217,6 +3217,8 @@ def post_fp_vasp (iter_index,
     for ss in system_index :
         sys_outcars = glob.glob(os.path.join(work_path, "task.%s.*/OUTCAR"%ss))
         sys_outcars.sort()
+        if len(sys_outcars) == 0:
+                raise RuntimeError("OUTCAR does not exist! please check fp_tasks.")
         tcount += len(sys_outcars)
         all_sys = None
         all_te = []


### PR DESCRIPTION
Add a error when OUTCAR does not exist in 02.fp/task.*.
When the vasp software is not running normally (such as mpirun commend not found), dpgen run will run normally.  I think the user should be notified of an error at this point.

Signed-off-by: ziqi-hu <51811006+ziqi-hu@users.noreply.github.com>