### PR TITLE
Dependency: Install pymatgen-analysis-defect for defect-related functionality

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
         PYMATGEN_VERSION: [2022.7.19]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8]
-        PYMATGEN_VERSION: [2019.1.13, 2019.7.30]
+        PYMATGEN_VERSION: [2022.7.19]
 
     steps:
     - uses: actions/checkout@v2

--- a/dpgen/auto_test/Interstitial.py
+++ b/dpgen/auto_test/Interstitial.py
@@ -7,10 +7,9 @@ from monty.serialization import loadfn, dumpfn
 try: 
     from pymatgen.analysis.defects.generators import InterstitialGenerator
 except ModuleNotFoundError:
-    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
-    print("Please install `pymatgen-analysis-defects`.")
-    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
-    os._exit(0)
+    raise ModuleNotFoundError("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.\n" \
+                              "Please install `pymatgen-analysis-defects`.\n" \
+                              "Kindly reminder: `pybind11>=2.4` need to be installed previously.")
 
 
 from pymatgen.core.structure import Structure

--- a/dpgen/auto_test/Interstitial.py
+++ b/dpgen/auto_test/Interstitial.py
@@ -4,7 +4,15 @@ import os
 import re
 
 from monty.serialization import loadfn, dumpfn
-from pymatgen.analysis.defects.generators import InterstitialGenerator
+try: 
+    from pymatgen.analysis.defects.generators import InterstitialGenerator
+except ModuleNotFoundError:
+    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
+    print("Please install `pymatgen-analysis-defects`.")
+    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
+    os._exit(0)
+
+
 from pymatgen.core.structure import Structure
 
 import dpgen.auto_test.lib.lammps as lammps

--- a/dpgen/auto_test/Vacancy.py
+++ b/dpgen/auto_test/Vacancy.py
@@ -7,10 +7,9 @@ from monty.serialization import loadfn, dumpfn
 try: 
     from pymatgen.analysis.defects.generators import VacancyGenerator
 except ModuleNotFoundError:
-    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
-    print("Please install `pymatgen-analysis-defects`.")
-    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
-    os._exit(0)
+    raise ModuleNotFoundError("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.\n" \
+                              "Please install `pymatgen-analysis-defects`.\n" \
+                              "Kindly reminder: `pybind11>=2.4` need to be installed previously.")
     
 from pymatgen.core.structure import Structure
 

--- a/dpgen/auto_test/Vacancy.py
+++ b/dpgen/auto_test/Vacancy.py
@@ -4,7 +4,14 @@ import os
 import re
 
 from monty.serialization import loadfn, dumpfn
-from pymatgen.analysis.defects.generators import VacancyGenerator
+try: 
+    from pymatgen.analysis.defects.generators import VacancyGenerator
+except ModuleNotFoundError:
+    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
+    print("Please install `pymatgen-analysis-defects`.")
+    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
+    os._exit(0)
+    
 from pymatgen.core.structure import Structure
 
 from dpgen import dlog

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-pymatgen==2019.6.5
-monty==2.0.4
-ase==3.17.0
-paramiko==2.6.0
-custodian==2019.2.10
-dpdata==0.2.6

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(path.join('dpgen', '_date.py'), 'w') as fp :
 install_requires=[
     'numpy>=1.14.3',
     'dpdata>=0.2.6',
-    'pymatgen>=2019.1.13',
+    'pymatgen>=2022.7.19',
     'ase',
     'monty>2.0.0',
     'paramiko',

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ install_requires=[
     'dpdispatcher>=0.3.11',
     'netCDF4',
     'dargs>=0.2.9',
+    'pybind11>=2.4',
+    'pymatgen-analysis-defects'
 ]
 
 setuptools.setup(

--- a/tests/auto_test/test_interstitial.py
+++ b/tests/auto_test/test_interstitial.py
@@ -7,7 +7,13 @@ from monty.serialization import loadfn, dumpfn
 from pymatgen.core import Structure
 from pymatgen.io.vasp import Incar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from pymatgen.analysis.defects.core import Interstitial as pmg_Interstitial
+try: 
+    from pymatgen.analysis.defects.core import Interstitial as pmg_Interstitial
+except ModuleNotFoundError:
+    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
+    print("Please install `pymatgen-analysis-defects`.")
+    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
+    os._exit(0)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 __package__ = 'auto_test'

--- a/tests/auto_test/test_interstitial.py
+++ b/tests/auto_test/test_interstitial.py
@@ -10,11 +10,10 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 try: 
     from pymatgen.analysis.defects.core import Interstitial as pmg_Interstitial
 except ModuleNotFoundError:
-    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
-    print("Please install `pymatgen-analysis-defects`.")
-    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
-    os._exit(0)
-
+    raise ModuleNotFoundError("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.\n" \
+                              "Please install `pymatgen-analysis-defects`.\n" \
+                              "Kindly reminder: `pybind11>=2.4` need to be installed previously.")
+                              
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 __package__ = 'auto_test'
 

--- a/tests/auto_test/test_vacancy.py
+++ b/tests/auto_test/test_vacancy.py
@@ -7,7 +7,13 @@ from monty.serialization import loadfn, dumpfn
 from pymatgen.core import Structure
 from pymatgen.io.vasp import Incar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from pymatgen.analysis.defects.core import Vacancy as pmg_Vacancy
+try:
+    from pymatgen.analysis.defects.core import Vacancy as pmg_Vacancy
+except ModuleNotFoundError:
+    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
+    print("Please install `pymatgen-analysis-defects`.")
+    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
+    os._exit(0)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 __package__ = 'auto_test'

--- a/tests/auto_test/test_vacancy.py
+++ b/tests/auto_test/test_vacancy.py
@@ -10,10 +10,9 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 try:
     from pymatgen.analysis.defects.core import Vacancy as pmg_Vacancy
 except ModuleNotFoundError:
-    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
-    print("Please install `pymatgen-analysis-defects`.")
-    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
-    os._exit(0)
+    raise ModuleNotFoundError("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.\n" \
+                              "Please install `pymatgen-analysis-defects`.\n" \
+                              "Kindly reminder: `pybind11>=2.4` need to be installed previously.")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 __package__ = 'auto_test'


### PR DESCRIPTION
- add `pymatgen-analysis-defect` and `pybind11` in `setup.py`.
- add reminder for user to install `pymatgen-analysis-defect` if this package is not in their environment.

Note: If `pymatgen-analysis-defect` is installed without `pybind11`, pip will raise errors.