### PR TITLE
loose check dpgen run jdata

### DIFF
--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -17,7 +17,7 @@ def run_mdata_arginfo() -> Argument:
 # basics
 def basic_args() -> List[Argument]:
     doc_type_map = 'Atom types.'
-    doc_mass_map = 'Standard atomic weights (default: "auto"). if one want to use isotopes, or non-standard element names, chemical symbols, or atomic number in the type_map list, please customize the mass_map list instead of using "auto". Tips: at present the default value will not be applied automatically, so you need to set "mass_map" manually in param.json.'
+    doc_mass_map = 'Standard atomic weights (default: "auto"). if one want to use isotopes, or non-standard element names, chemical symbols, or atomic number in the type_map list, please customize the mass_map list instead of using "auto".'
     doc_use_ele_temp = 'Currently only support fp_style vasp. \n\n\
 - 0: no electron temperature. \n\n\
 - 1: eletron temperature as frame parameter. \n\n\

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -62,10 +62,11 @@ from dpgen.generator.lib.cp2k import make_cp2k_input, make_cp2k_input_from_exter
 from dpgen.generator.lib.ele_temp import NBandsEsti
 from dpgen.remote.decide_machine import convert_mdata
 from dpgen.dispatcher.Dispatcher import Dispatcher, _split_tasks, make_dispatcher, make_submission
-from dpgen.util import sepline, expand_sys_str
+from dpgen.util import sepline, expand_sys_str, normalize
 from dpgen import ROOT_PATH
 from pymatgen.io.vasp import Incar,Kpoints,Potcar
 from dpgen.auto_test.lib.vasp import make_kspacing_kpoints
+from .arginfo import run_jdata_arginfo
 
 
 template_name = 'template'
@@ -3717,6 +3718,9 @@ def run_iter (param_file, machine_file) :
            jdata = json.load (fp)
        with open (machine_file, 'r') as fp:
            mdata = json.load (fp)
+
+    jdata_arginfo = run_jdata_arginfo()
+    jdata = normalize(jdata_arginfo, jdata, strict_check=False)
 
     update_mass_map(jdata)
         


### PR DESCRIPTION
Since there are lots of parameters still not added (#771, #773, #774, #781, #782), we only enable loose check for `dpgen run` (i.e. `strict_check=False`).