### PR TITLE
Fix incompatibility of autotest module with latest pymatgen>2022.7.19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
         PYMATGEN_VERSION: [2022.7.19]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8]
-        PYMATGEN_VERSION: [2019.1.13, 2019.7.30]
+        PYMATGEN_VERSION: [2022.7.19]
 
     steps:
     - uses: actions/checkout@v2

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+formats: all
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+   configuration: doc/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 formats: all
@@ -21,4 +21,4 @@ formats: all
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
-   - requirements: docs/requirements.txt
+   - requirements: doc/requirements.txt

--- a/dpgen/auto_test/Interstitial.py
+++ b/dpgen/auto_test/Interstitial.py
@@ -2,6 +2,7 @@ import glob
 import json
 import os
 import re
+import numpy as np
 
 from monty.serialization import loadfn, dumpfn
 from pymatgen.analysis.defects.generators import InterstitialGenerator
@@ -147,9 +148,10 @@ class Interstitial(Property):
                     os.remove(insert_element_task)
 
                 for ii in self.insert_ele:
-                    vds = InterstitialGenerator(ss, ii)
+                    pre_vds = InterstitialGenerator()
+                    vds = pre_vds.generate(ss, {self.insert_ele[0]: [[0, 0.2, 0.5]]})
                     for jj in vds:
-                        temp = jj.generate_defect_structure(self.supercell)
+                        temp = jj.get_supercell_structure(sc_mat=np.eye(3) * self.supercell)
                         smallest_distance = list(set(temp.distance_matrix.ravel()))[1]
                         if 'conf_filters' in self.parameter and 'min_dist' in self.parameter['conf_filters']:
                             min_dist = self.parameter['conf_filters']['min_dist']
@@ -188,6 +190,9 @@ class Interstitial(Property):
 
 
                 if 'bcc_self' in self.parameter and self.parameter['bcc_self']:
+                    super_size = self.supercell[0] * self.supercell[1] * self.supercell[2]
+                    num_atom = super_size * 2
+                    chl = -num_atom - 2
                     os.chdir(path_to_work)
                     with open('POSCAR', 'r') as fin:
                         fin.readline()
@@ -210,7 +215,7 @@ class Interstitial(Property):
                     with open(insert_element_task, 'a+') as fout:
                         print(self.insert_ele[0], file=fout)
                     dumpfn(self.supercell, 'supercell.json')
-                    pos_line[-2] = '%.6f' % float(latt_param/4/super_latt_param) + ' ' + '%.6f' % float(latt_param/2/super_latt_param) + ' 0.000000 ' + self.insert_ele[0]
+                    pos_line[chl] = '%.6f' % float(latt_param/4/super_latt_param) + ' ' + '%.6f' % float(latt_param/2/super_latt_param) + ' 0.000000 ' + self.insert_ele[0]
                     with open('POSCAR', 'w+') as fout:
                         for ii in pos_line:
                                 print(ii, file=fout)
@@ -224,7 +229,7 @@ class Interstitial(Property):
                     with open(insert_element_task, 'a+') as fout:
                         print(self.insert_ele[0], file=fout)
                     dumpfn(self.supercell, 'supercell.json')
-                    pos_line[-2] = '%.6f' % float(latt_param/2/super_latt_param) + ' ' + '%.6f' % float(latt_param/2/super_latt_param) + ' 0.000000 ' + self.insert_ele[0]
+                    pos_line[chl] = '%.6f' % float(latt_param/2/super_latt_param) + ' ' + '%.6f' % float(latt_param/2/super_latt_param) + ' 0.000000 ' + self.insert_ele[0]
                     with open('POSCAR', 'w+') as fout:
                         for ii in pos_line:
                                 print(ii, file=fout)
@@ -238,7 +243,7 @@ class Interstitial(Property):
                     with open(insert_element_task, 'a+') as fout:
                         print(self.insert_ele[0], file=fout)
                     dumpfn(self.supercell, 'supercell.json')
-                    pos_line[-2] = '%.6f' % float(latt_param/4/super_latt_param) + ' ' + '%.6f' % float(latt_param/4/super_latt_param) + ' ' + '%.6f' % float(latt_param/4/super_latt_param) + ' ' + self.insert_ele[0]
+                    pos_line[chl] = '%.6f' % float(latt_param/4/super_latt_param) + ' ' + '%.6f' % float(latt_param/4/super_latt_param) + ' ' + '%.6f' % float(latt_param/4/super_latt_param) + ' ' + self.insert_ele[0]
                     with open('POSCAR', 'w+') as fout:
                         for ii in pos_line:
                                 print(ii, file=fout)
@@ -258,7 +263,7 @@ class Interstitial(Property):
                     with open(insert_element_task, 'a+') as fout:
                         print(self.insert_ele[0], file=fout)
                     dumpfn(self.supercell, 'supercell.json')
-                    pos_line[-2] = '%.6f' % float(latt_param/3/super_latt_param) + ' ' + '%.6f' % float(latt_param/3/super_latt_param) + ' ' + '%.6f' % float(latt_param/3/super_latt_param) + ' ' + self.insert_ele[0]
+                    pos_line[chl] = '%.6f' % float(latt_param/3/super_latt_param) + ' ' + '%.6f' % float(latt_param/3/super_latt_param) + ' ' + '%.6f' % float(latt_param/3/super_latt_param) + ' ' + self.insert_ele[0]
                     pos_line[replace_label] = '%.6f' % float(latt_param/3*2/super_latt_param) + ' ' + '%.6f' % float(latt_param/3*2/super_latt_param) + ' ' + '%.6f' % float(latt_param/3*2/super_latt_param) + ' ' + self.insert_ele[0]
 
                     with open('POSCAR', 'w+') as fout:
@@ -274,7 +279,7 @@ class Interstitial(Property):
                     with open(insert_element_task, 'a+') as fout:
                         print(self.insert_ele[0], file=fout)
                     dumpfn(self.supercell, 'supercell.json')
-                    pos_line[-2] = '%.6f' % float((latt_param+2.1/2**0.5)/2/super_latt_param) + ' ' + '%.6f' % float((latt_param-2.1/2**0.5)/2/super_latt_param) + ' ' + '%.6f' % float(latt_param/2/super_latt_param) + ' ' + self.insert_ele[0]
+                    pos_line[chl] = '%.6f' % float((latt_param+2.1/2**0.5)/2/super_latt_param) + ' ' + '%.6f' % float((latt_param-2.1/2**0.5)/2/super_latt_param) + ' ' + '%.6f' % float(latt_param/2/super_latt_param) + ' ' + self.insert_ele[0]
                     pos_line[replace_label] = '%.6f' % float((latt_param-2.1/2**0.5)/2/super_latt_param) + ' ' + '%.6f' % float((latt_param+2.1/2**0.5)/2/super_latt_param) + ' ' + '%.6f' % float(latt_param/2/super_latt_param) + ' ' + self.insert_ele[0]
 
                     with open('POSCAR', 'w+') as fout:
@@ -290,7 +295,7 @@ class Interstitial(Property):
                     with open(insert_element_task, 'a+') as fout:
                         print(self.insert_ele[0], file=fout)
                     dumpfn(self.supercell, 'supercell.json')
-                    pos_line[-2] = '%.6f' % float(latt_param/2/super_latt_param) + ' ' + '%.6f' % float(latt_param/2/super_latt_param) + ' ' + '%.6f' % float((latt_param-2.1)/2/super_latt_param) + ' ' + self.insert_ele[0]
+                    pos_line[chl] = '%.6f' % float(latt_param/2/super_latt_param) + ' ' + '%.6f' % float(latt_param/2/super_latt_param) + ' ' + '%.6f' % float((latt_param-2.1)/2/super_latt_param) + ' ' + self.insert_ele[0]
                     pos_line[replace_label] = '%.6f' % float(latt_param/2/super_latt_param) + ' ' + '%.6f' % float(latt_param/2/super_latt_param) + ' ' + '%.6f' % float((latt_param+2.1)/2/super_latt_param) + ' ' + self.insert_ele[0]
 
                     with open('POSCAR', 'w+') as fout:

--- a/dpgen/auto_test/Interstitial.py
+++ b/dpgen/auto_test/Interstitial.py
@@ -6,6 +6,13 @@ import numpy as np
 
 from monty.serialization import loadfn, dumpfn
 from pymatgen.analysis.defects.generators import InterstitialGenerator
+try:
+    from pymatgen.analysis.defects.generators import InterstitialGenerator
+except ModuleNotFoundError:
+    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
+    print("Please install `pymatgen-analysis-defects`.")
+    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
+    os._exit(0)
 from pymatgen.core.structure import Structure
 
 import dpgen.auto_test.lib.lammps as lammps

--- a/dpgen/auto_test/Interstitial.py
+++ b/dpgen/auto_test/Interstitial.py
@@ -151,7 +151,7 @@ class Interstitial(Property):
                     pre_vds = InterstitialGenerator()
                     vds = pre_vds.generate(ss, {self.insert_ele[0]: [[0, 0.2, 0.5]]})
                     for jj in vds:
-                        temp = jj.get_supercell_structure(sc_mat=np.eye(3) * self.supercell)
+                        temp = jj.get_supercell_structure(sc_mat=np.diag(self.supercell, k=0))
                         smallest_distance = list(set(temp.distance_matrix.ravel()))[1]
                         if 'conf_filters' in self.parameter and 'min_dist' in self.parameter['conf_filters']:
                             min_dist = self.parameter['conf_filters']['min_dist']

--- a/dpgen/auto_test/Interstitial.py
+++ b/dpgen/auto_test/Interstitial.py
@@ -149,7 +149,7 @@ class Interstitial(Property):
 
                 for ii in self.insert_ele:
                     pre_vds = InterstitialGenerator()
-                    vds = pre_vds.generate(ss, {self.insert_ele[0]: [[0, 0.2, 0.5]]})
+                    vds = pre_vds.generate(ss, {ii: [[0.1,0.1,0.1]]})
                     for jj in vds:
                         temp = jj.get_supercell_structure(sc_mat=np.diag(self.supercell, k=0))
                         smallest_distance = list(set(temp.distance_matrix.ravel()))[1]

--- a/dpgen/auto_test/Interstitial.py
+++ b/dpgen/auto_test/Interstitial.py
@@ -6,13 +6,6 @@ import numpy as np
 
 from monty.serialization import loadfn, dumpfn
 from pymatgen.analysis.defects.generators import InterstitialGenerator
-try:
-    from pymatgen.analysis.defects.generators import InterstitialGenerator
-except ModuleNotFoundError:
-    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
-    print("Please install `pymatgen-analysis-defects`.")
-    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
-    os._exit(0)
 from pymatgen.core.structure import Structure
 
 import dpgen.auto_test.lib.lammps as lammps

--- a/dpgen/auto_test/Vacancy.py
+++ b/dpgen/auto_test/Vacancy.py
@@ -139,7 +139,7 @@ class Vacancy(Property):
                 vds = pre_vds.generate(ss)
                 dss = []
                 for jj in vds:
-                    dss.append(jj.get_supercell_structure(sc_mat=np.eye(3)*self.supercell))
+                    dss.append(jj.get_supercell_structure(sc_mat=np.diag(self.supercell, k=0))
 
                 print('gen vacancy with supercell ' + str(self.supercell))
                 os.chdir(path_to_work)

--- a/dpgen/auto_test/Vacancy.py
+++ b/dpgen/auto_test/Vacancy.py
@@ -139,7 +139,7 @@ class Vacancy(Property):
                 vds = pre_vds.generate(ss)
                 dss = []
                 for jj in vds:
-                    dss.append(jj.get_supercell_structure(sc_mat=np.diag(self.supercell, k=0))
+                    dss.append(jj.get_supercell_structure(sc_mat=np.diag(self.supercell, k=0))）
 
                 print('gen vacancy with supercell ' + str(self.supercell))
                 os.chdir(path_to_work)

--- a/dpgen/auto_test/Vacancy.py
+++ b/dpgen/auto_test/Vacancy.py
@@ -5,13 +5,7 @@ import re
 import numpy as np
 
 from monty.serialization import loadfn, dumpfn
-try:
-    from pymatgen.analysis.defects.generators import VacancyGenerator
-except ModuleNotFoundError:
-    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
-    print("Please install `pymatgen-analysis-defects`.")
-    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
-    os._exit(0)
+from pymatgen.analysis.defects.generators import VacancyGenerator
 from pymatgen.core.structure import Structure
 
 from dpgen import dlog

--- a/dpgen/auto_test/Vacancy.py
+++ b/dpgen/auto_test/Vacancy.py
@@ -2,6 +2,7 @@ import glob
 import json
 import os
 import re
+import numpy as np
 
 from monty.serialization import loadfn, dumpfn
 from pymatgen.analysis.defects.generators import VacancyGenerator
@@ -134,10 +135,11 @@ class Vacancy(Property):
                 else:
                     ss = Structure.from_file(equi_contcar)
 
-                vds = VacancyGenerator(ss)
+                pre_vds = VacancyGenerator()
+                vds = pre_vds.generate(ss)
                 dss = []
                 for jj in vds:
-                    dss.append(jj.generate_defect_structure(self.supercell))
+                    dss.append(jj.get_supercell_structure(sc_mat=np.eye(3)*self.supercell))
 
                 print('gen vacancy with supercell ' + str(self.supercell))
                 os.chdir(path_to_work)

--- a/dpgen/auto_test/Vacancy.py
+++ b/dpgen/auto_test/Vacancy.py
@@ -5,7 +5,13 @@ import re
 import numpy as np
 
 from monty.serialization import loadfn, dumpfn
-from pymatgen.analysis.defects.generators import VacancyGenerator
+try:
+    from pymatgen.analysis.defects.generators import VacancyGenerator
+except ModuleNotFoundError:
+    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
+    print("Please install `pymatgen-analysis-defects`.")
+    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
+    os._exit(0)
 from pymatgen.core.structure import Structure
 
 from dpgen import dlog

--- a/dpgen/auto_test/Vacancy.py
+++ b/dpgen/auto_test/Vacancy.py
@@ -139,7 +139,7 @@ class Vacancy(Property):
                 vds = pre_vds.generate(ss)
                 dss = []
                 for jj in vds:
-                    dss.append(jj.get_supercell_structure(sc_mat=np.diag(self.supercell, k=0))）
+                    dss.append(jj.get_supercell_structure(sc_mat=np.diag(self.supercell, k=0)))
 
                 print('gen vacancy with supercell ' + str(self.supercell))
                 os.chdir(path_to_work)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(path.join('dpgen', '_date.py'), 'w') as fp :
 install_requires=[
     'numpy>=1.14.3',
     'dpdata>=0.2.6',
-    'pymatgen>=2019.1.13',
+    'pymatgen>=2022.7.19',
     'ase',
     'monty>2.0.0',
     'paramiko',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ install_requires=[
     'dpdispatcher>=0.3.11',
     'netCDF4',
     'dargs>=0.2.9',
-    'pybind11>=2.4',
     'pymatgen-analysis-defects'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ install_requires=[
     'dpdispatcher>=0.3.11',
     'netCDF4',
     'dargs>=0.2.9',
+    'pybind11>=2.4',
+    'pymatgen-analysis-defects'
 ]
 
 setuptools.setup(

--- a/tests/auto_test/test_interstitial.py
+++ b/tests/auto_test/test_interstitial.py
@@ -7,7 +7,13 @@ from monty.serialization import loadfn, dumpfn
 from pymatgen.core import Structure
 from pymatgen.io.vasp import Incar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from pymatgen.analysis.defects.core import Interstitial as pmg_Interstitial
+try:
+    from pymatgen.analysis.defects.core import Interstitial as pmg_Interstitial
+except ModuleNotFoundError:
+    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
+    print("Please install `pymatgen-analysis-defects`.")
+    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
+    os._exit(0)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 __package__ = 'auto_test'

--- a/tests/auto_test/test_interstitial.py
+++ b/tests/auto_test/test_interstitial.py
@@ -7,13 +7,7 @@ from monty.serialization import loadfn, dumpfn
 from pymatgen.core import Structure
 from pymatgen.io.vasp import Incar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-try:
-    from pymatgen.analysis.defects.core import Interstitial as pmg_Interstitial
-except ModuleNotFoundError:
-    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
-    print("Please install `pymatgen-analysis-defects`.")
-    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
-    os._exit(0)
+from pymatgen.analysis.defects.core import Interstitial as pmg_Interstitial
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 __package__ = 'auto_test'

--- a/tests/auto_test/test_interstitial.py
+++ b/tests/auto_test/test_interstitial.py
@@ -85,16 +85,16 @@ class TestInterstitial(unittest.TestCase):
             st_file = os.path.join(ii, 'POSCAR')
             self.assertTrue(os.path.isfile(st_file))
             st0 = Structure.from_file(st_file)
-            inter_site = st0[-1]
-            inter = pmg_Interstitial(ref_st, inter_site, charge=0.0)
-            st1 = inter.generate_defect_structure(self.prop_param[0]['supercell'])
+            inter_site = st0[0]
+            inter = pmg_Interstitial(ref_st, inter_site)
+            st1 = inter.get_supercell_structure(sc_mat=np.eye(3)*self.prop_param[0]['supercell'])
             self.assertEqual(st0, st1)
 
         for ii in dfm_dirs[4:]:
             st_file = os.path.join(ii, 'POSCAR')
             self.assertTrue(os.path.isfile(st_file))
             st0 = Structure.from_file(st_file)
-            inter_site1 = st0.pop(-1)
+            inter_site1 = st0.pop(0)
             inter_site2 = st0.pop(-1)
             center = (inter_site1.coords + inter_site2.coords) / 2
             self.assertTrue((center[0] - center[1]) < 1e-4)

--- a/tests/auto_test/test_vacancy.py
+++ b/tests/auto_test/test_vacancy.py
@@ -8,6 +8,13 @@ from pymatgen.core import Structure
 from pymatgen.io.vasp import Incar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.analysis.defects.core import Vacancy as pmg_Vacancy
+try:
+    from pymatgen.analysis.defects.core import Vacancy as pmg_Vacancy
+except ModuleNotFoundError:
+    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
+    print("Please install `pymatgen-analysis-defects`.")
+    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
+    os._exit(0)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 __package__ = 'auto_test'

--- a/tests/auto_test/test_vacancy.py
+++ b/tests/auto_test/test_vacancy.py
@@ -85,6 +85,6 @@ class TestVacancy(unittest.TestCase):
             self.assertTrue(os.path.isfile(st_file))
             st0 = Structure.from_file(st_file)
             vac_site = equiv_site_seq.pop(0)
-            vac = pmg_Vacancy(ref_st, vac_site[0], charge=0.0)
-            st1 = vac.generate_defect_structure(self.prop_param[0]['supercell'])
+            vac = pmg_Vacancy(ref_st, vac_site[0])
+            st1 = vac.get_supercell_structure(sc_mat=np.eye(3)*self.prop_param[0]['supercell'])
             self.assertEqual(st0, st1)

--- a/tests/auto_test/test_vacancy.py
+++ b/tests/auto_test/test_vacancy.py
@@ -8,13 +8,6 @@ from pymatgen.core import Structure
 from pymatgen.io.vasp import Incar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.analysis.defects.core import Vacancy as pmg_Vacancy
-try:
-    from pymatgen.analysis.defects.core import Vacancy as pmg_Vacancy
-except ModuleNotFoundError:
-    print("pymatgen==2022.7.19 is the final release with `pymatgen.analysis.defects` module. Please check the version of pymatgen.")
-    print("Please install `pymatgen-analysis-defects`.")
-    print("Kindly reminder: `pybind11>=2.4` need to be installed previously.")
-    os._exit(0)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 __package__ = 'auto_test'


### PR DESCRIPTION
Fix incompatibility of Interstitial.py and Vacancy.py with pymatgen>2022.7.9
add pymatgen-analysis-defect and pybind11 in setup.py.
add reminder for user to install pymatgen-analysis-defect if this package is not in their environment
