### PR TITLE
remove `_link_fp_vasp_pp` from `make_fp_gaussian`

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -2790,8 +2790,7 @@ def make_fp_gaussian(iter_index,
         with open('input', 'w') as fp:
             fp.write(ret)
         os.chdir(cwd)
-    # link pp files
-    _link_fp_vasp_pp(iter_index, jdata)
+
 
 def make_fp_cp2k (iter_index,
                   jdata):


### PR DESCRIPTION
Fixes #970. It's not required for gaussian.