### PR TITLE
fix : autotest relaxation TOC

### DIFF
--- a/doc/autotest/relaxation/index.rst
+++ b/doc/autotest/relaxation/index.rst
@@ -5,7 +5,7 @@ Relaxation
 .. toctree::
    :maxdepth: 2
 
-   Refine-get-started-and-input-examples
+   Relaxation-get-started-and-input-examples
    Relaxation-make
    Relaxation-run
    Relaxation-post


### PR DESCRIPTION
fix typo `Relaxation-get-started-and-input-examples`