### PR TITLE
fix codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: pip install coverage codecov pymatgen==${{ matrix.PYMATGEN_VERSION }} -e .
+      run: pip install coverage pymatgen==${{ matrix.PYMATGEN_VERSION }} -e .
     - name: Test
       run: coverage run --source=./dpgen -m unittest -v && coverage report
-    - run: codecov
+    - uses: codecov/codecov-action@v3


### PR DESCRIPTION
Codecov python package is deprecated and does not work any more. This patch migrates it to another version.