### PR TITLE
Fix: remove the reading of `ntype` when treating ABACUS related info

### DIFF
--- a/dpgen/auto_test/ABACUS.py
+++ b/dpgen/auto_test/ABACUS.py
@@ -151,8 +151,6 @@ class ABACUS(Task):
         if 'basis_type' not in incar:
             dlog.info("'basis_type' is not defined, set to be 'pw'!")
             self.modify_input(incar,'basis_type','pw')
-        if 'ntype' not in incar:
-            raise RuntimeError("ntype is not defined in INPUT")
         if 'lcao' in incar['basis_type'].lower() and not self.if_define_orb_file:
             mess = "The basis_type is %s, but not define orbital file!!!" % incar['basis_type']
             raise RuntimeError(mess)

--- a/dpgen/generator/lib/abacus_scf.py
+++ b/dpgen/generator/lib/abacus_scf.py
@@ -1,5 +1,5 @@
 import numpy as np
-from dpdata.abacus.scf import get_cell, get_coords
+from dpdata.abacus.scf import get_cell, get_coords,get_nele_from_stru
 from dpgen.auto_test.lib import vasp
 import os
 bohr2ang = 0.52917721067
@@ -21,18 +21,13 @@ def make_abacus_scf_input(fp_params):
     ret = "INPUT_PARAMETERS\n"
     ret += "calculation scf\n"
     for key in fp_params:
-        if key == "ntype":
-            fp_params["ntype"] = int(fp_params["ntype"])
-            assert(fp_params['ntype'] >= 0 and type(fp_params["ntype"]) == int),  "'ntype' should be a positive integer."
-            ret += "ntype %d\n" % fp_params['ntype']
-        #ret += "pseudo_dir ./\n"
-        elif key == "ecutwfc":
+        if key == "ecutwfc":
             fp_params["ecutwfc"] = float(fp_params["ecutwfc"])
-            assert(fp_params["ecutwfc"] >= 0) ,  "'ntype' should be non-negative."
+            assert(fp_params["ecutwfc"] >= 0) ,  "'ecutwfc' should be non-negative."
             ret += "ecutwfc %f\n" % fp_params["ecutwfc"]
         elif key == "kspacing":
             fp_params["kspacing"] = float(fp_params["kspacing"])
-            assert(fp_params["kspacing"] >= 0) ,  "'ntype' should be non-negative."
+            assert(fp_params["kspacing"] >= 0) ,  "'kspacing' should be non-negative."
             ret += "kspacing %f\n" % fp_params["kspacing"]
         elif key == "scf_thr":
             fp_params["scf_thr"] = float(fp_params["scf_thr"])
@@ -185,14 +180,9 @@ def get_abacus_input_parameters(INPUT):
     fp.close()
     return input_parameters
 
-def get_mass_from_STRU(geometry_inlines, inlines, atom_names):
-    nele = None
-    for line in inlines:
-        if line.split() == []:
-            continue
-        if "ntype" in line and "ntype" == line.split()[0]:
-            nele = int(line.split()[1])
-    assert(nele is not None)
+def get_mass_from_STRU(geometry_inlines, atom_names):
+    nele = get_nele_from_stru(geometry_inlines)
+    assert(nele > 0)
     mass_list = [0 for i in atom_names]
     pp_file_list = [i for i in atom_names]
     for iline, line in enumerate(geometry_inlines):
@@ -261,21 +251,9 @@ def get_abacus_STRU(STRU, INPUT = None, n_ele = None):
         if line.split() == [] or len(line) == 0:
             del geometry_inlines[iline]
     geometry_inlines.append("")
-    celldm, cell = get_cell(geometry_inlines) 
-    if n_ele is None and INPUT is not None:
-        assert(os.path.isfile(INPUT)), "file %s should exists" % INPUT
-        with open(INPUT, 'r') as fp:
-            inlines = fp.read().split('\n')
-        atom_names, natoms, types, coords = get_coords(celldm, cell, geometry_inlines, inlines) 
-    elif n_ele is not None and INPUT is None:
-        assert(n_ele > 0)
-        inlines = ["ntype %d" %n_ele]
-        atom_names, natoms, types, coords = get_coords(celldm, cell, geometry_inlines, inlines)
-    else:
-        atom_names, atom_numbs = get_natoms_from_stru(geometry_inlines)
-        inlines = ["ntype %d" %len(atom_numbs)]
-        atom_names, natoms, types, coords = get_coords(celldm, cell, geometry_inlines, inlines)
-    masses, pp_files = get_mass_from_STRU(geometry_inlines, inlines, atom_names)
+    celldm, cell = get_cell(geometry_inlines)
+    atom_names, natoms, types, coords = get_coords(celldm, cell, geometry_inlines)
+    masses, pp_files = get_mass_from_STRU(geometry_inlines, atom_names)
     orb_files, dpks_descriptor = get_additional_from_STRU(geometry_inlines, len(masses))
     data = {}
     data['atom_names'] = atom_names

--- a/tests/auto_test/abacus_input/INPUT
+++ b/tests/auto_test/abacus_input/INPUT
@@ -2,7 +2,6 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix          ABACUS
 calculation     relax
-ntype           1
 symmetry        1
 pseudo_type     upf201
 

--- a/tests/auto_test/equi/abacus/INPUT
+++ b/tests/auto_test/equi/abacus/INPUT
@@ -2,7 +2,6 @@ INPUT_PARAMETERS
 #Parameters (5.Mixing)
 suffix ABACUS
 calculation cell-relax
-ntype 1
 symmetry 1
 pseudo_type upf201
 ecutwfc 60

--- a/tests/generator/abacus/INPUT.diy
+++ b/tests/generator/abacus/INPUT.diy
@@ -1,4 +1,3 @@
-ntype		   	2
 ecutwfc   		80
 scf_thr   		1e-7
 scf_nmax   		50

--- a/tests/generator/param-methane-abacus.json
+++ b/tests/generator/param-methane-abacus.json
@@ -135,7 +135,6 @@
   "_fp_kpt_file":	  "./abacus/KPT",
   "_k_points":		[3,3,3,0,0,0],
   "user_fp_params":{
-    "ntype": 2,
     "ecutwfc": 80,
     "scf_thr": 1e-7,
     "scf_nmax": 50,

--- a/tests/generator/test_make_fp.py
+++ b/tests/generator/test_make_fp.py
@@ -155,7 +155,6 @@ IN.PSP3 = N.SG15.PBE.UPF\n";
 
 abacus_input_ref = "INPUT_PARAMETERS\n\
 calculation scf\n\
-ntype 2\n\
 ecutwfc 80.000000\n\
 scf_thr 1.000000e-07\n\
 scf_nmax 50\n\


### PR DESCRIPTION
The latest ABACUS 3.0.5 have removed the key word ·ntype· 