### PR TITLE
fix doc: "structures" should be a list

### DIFF
--- a/doc/autotest/Auto-test.md
+++ b/doc/autotest/Auto-test.md
@@ -15,7 +15,7 @@ If, for some reasons, the main program terminated at stage `run`, one can easily
 `relax.json` is the parameter file. An example for `deepmd` relaxation is given as:
 ```json
 {
-        "structures":   "confs/mp-*",
+        "structures":   ["confs/mp-*"],
         "interaction": {
                 "type":         "deepmd",
                 "model":        "frozen_model.pb",


### PR DESCRIPTION
The type of parameter "structures" in `relaxation.json` of `dpgen autotest` should be a list. Fix the wrong type in Autotest Overview.