### PR TITLE
replace distutils.version.LooseVersion by packaging.version.Version

### DIFF
--- a/dpgen/auto_test/common_equi.py
+++ b/dpgen/auto_test/common_equi.py
@@ -12,7 +12,7 @@ from dpgen import dlog
 from dpgen.auto_test.calculator import make_calculator
 from dpgen.auto_test.mpdb import get_structure
 from dpgen.dispatcher.Dispatcher import make_dispatcher
-from distutils.version import LooseVersion
+from packaging.version import Version
 from dpgen.dispatcher.Dispatcher import make_submission
 from dpgen.remote.decide_machine import convert_mdata
 from dpgen.auto_test.lib.utils import create_path
@@ -177,7 +177,7 @@ def run_equi(confs,
     print("%s --> Runing... " % (work_path))
 
     api_version = mdata.get('api_version', '0.9')
-    if LooseVersion(api_version) < LooseVersion('1.0'):
+    if Version(api_version) < Version('1.0'):
         warnings.warn(f"the dpdispatcher will be updated to new version."
                       f"And the interface may be changed. Please check the documents for more details")
         disp = make_dispatcher(machine, resources, work_path, run_tasks, group_size)
@@ -191,7 +191,7 @@ def run_equi(confs,
                       backward_files,
                       outlog='outlog',
                       errlog='errlog')
-    elif LooseVersion(api_version) >= LooseVersion('1.0'):
+    elif Version(api_version) >= Version('1.0'):
     
         submission = make_submission(
             mdata_machine=machine,

--- a/dpgen/auto_test/common_prop.py
+++ b/dpgen/auto_test/common_prop.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import glob
 import os
 import warnings
@@ -191,7 +191,7 @@ def worker(work_path,
     run_tasks = [os.path.basename(ii) for ii in all_task]
     machine, resources, command, group_size = util.get_machine_info(mdata, inter_type)
     api_version = mdata.get('api_version', '0.9')
-    if LooseVersion(api_version) < LooseVersion('1.0'):
+    if Version(api_version) < Version('1.0'):
         warnings.warn(f"the dpdispatcher will be updated to new version."
             f"And the interface may be changed. Please check the documents for more details")
         disp = make_dispatcher(machine, resources, work_path, run_tasks, group_size)
@@ -205,7 +205,7 @@ def worker(work_path,
                   backward_files,
                   outlog='outlog',
                   errlog='errlog')
-    elif LooseVersion(api_version) >= LooseVersion('1.0'):
+    elif Version(api_version) >= Version('1.0'):
         submission = make_submission(
                 mdata_machine=machine,
                 mdata_resources=resources,

--- a/dpgen/auto_test/lib/lammps.py
+++ b/dpgen/auto_test/lib/lammps.py
@@ -4,7 +4,7 @@ import random, os, sys
 import dpdata
 import subprocess as sp
 import dpgen.auto_test.lib.util as util
-from distutils.version import LooseVersion
+from packaging.version import Version
 from dpdata.periodic_table import Element
 
 
@@ -103,7 +103,7 @@ def inter_deepmd(param):
     model_list = ""
     for ii in models:
         model_list += ii + " "
-    if LooseVersion(deepmd_version) < LooseVersion('1'):
+    if Version(deepmd_version) < Version('1'):
         ## DeePMD-kit version == 0.x
         if len(models) > 1:
             ret += '%s 10 model_devi.out\n' % model_list

--- a/dpgen/data/gen.py
+++ b/dpgen/data/gen.py
@@ -20,7 +20,7 @@ import dpgen.data.tools.fcc as fcc
 import dpgen.data.tools.bcc as bcc
 import dpgen.data.tools.diamond as diamond
 import dpgen.data.tools.sc as sc
-from distutils.version import LooseVersion
+from packaging.version import Version
 from dpgen.generator.lib.vasp import incar_upper
 from dpgen.generator.lib.utils import symlink_user_forward_files
 from dpgen.generator.lib.abacus_scf import get_abacus_input_parameters, get_abacus_STRU, make_supercell_abacus, make_abacus_scf_stru\
@@ -1061,7 +1061,7 @@ def run_vasp_relax(jdata, mdata):
     run_tasks = [os.path.basename(ii) for ii in relax_run_tasks]
 
     api_version = mdata.get('api_version', '0.9')
-    if LooseVersion(api_version) < LooseVersion('1.0'):
+    if Version(api_version) < Version('1.0'):
         warnings.warn(f"the dpdispatcher will be updated to new version."
             f"And the interface may be changed. Please check the documents for more details")
         dispatcher = make_dispatcher(mdata['fp_machine'], mdata['fp_resources'], work_dir, run_tasks, fp_group_size)
@@ -1074,7 +1074,7 @@ def run_vasp_relax(jdata, mdata):
                        forward_files,
                        backward_files)
 
-    elif LooseVersion(api_version) >= LooseVersion('1.0'):
+    elif Version(api_version) >= Version('1.0'):
         submission = make_submission(
             mdata['fp_machine'],
             mdata['fp_resources'],
@@ -1197,7 +1197,7 @@ def run_abacus_relax(jdata, mdata):
     run_tasks = [os.path.basename(ii) for ii in relax_run_tasks]
 
     api_version = mdata.get('api_version', '0.9')
-    if LooseVersion(api_version) < LooseVersion('1.0'):
+    if Version(api_version) < Version('1.0'):
         warnings.warn(f"the dpdispatcher will be updated to new version."
             f"And the interface may be changed. Please check the documents for more details")
         dispatcher = make_dispatcher(mdata['fp_machine'], mdata['fp_resources'], work_dir, run_tasks, fp_group_size)
@@ -1210,7 +1210,7 @@ def run_abacus_relax(jdata, mdata):
                        forward_files,
                        backward_files)
 
-    elif LooseVersion(api_version) >= LooseVersion('1.0'):
+    elif Version(api_version) >= Version('1.0'):
         submission = make_submission(
             mdata['fp_machine'],
             mdata['fp_resources'],
@@ -1264,7 +1264,7 @@ def run_vasp_md(jdata, mdata):
     #dlog.info("md_work_dir", work_dir)
     #dlog.info("run_tasks",run_tasks)
     api_version = mdata.get('api_version', '0.9')
-    if LooseVersion(api_version) < LooseVersion('1.0'):
+    if Version(api_version) < Version('1.0'):
         warnings.warn(f"the dpdispatcher will be updated to new version."
             f"And the interface may be changed. Please check the documents for more details")
         dispatcher = make_dispatcher(mdata['fp_machine'], mdata['fp_resources'], work_dir, run_tasks, fp_group_size)
@@ -1277,7 +1277,7 @@ def run_vasp_md(jdata, mdata):
                        forward_files,
                        backward_files)
 
-    elif LooseVersion(api_version) >= LooseVersion('1.0'):
+    elif Version(api_version) >= Version('1.0'):
         submission = make_submission(
             mdata['fp_machine'],
             mdata['fp_resources'],
@@ -1344,7 +1344,7 @@ def run_abacus_md(jdata, mdata):
     #dlog.info("md_work_dir", work_dir)
     #dlog.info("run_tasks",run_tasks)
     api_version = mdata.get('api_version', '0.9')
-    if LooseVersion(api_version) < LooseVersion('1.0'):
+    if Version(api_version) < Version('1.0'):
         warnings.warn(f"the dpdispatcher will be updated to new version."
             f"And the interface may be changed. Please check the documents for more details")
         dispatcher = make_dispatcher(mdata['fp_machine'], mdata['fp_resources'], work_dir, run_tasks, fp_group_size)
@@ -1357,7 +1357,7 @@ def run_abacus_md(jdata, mdata):
                        forward_files,
                        backward_files)
 
-    elif LooseVersion(api_version) >= LooseVersion('1.0'):
+    elif Version(api_version) >= Version('1.0'):
         submission = make_submission(
             mdata['fp_machine'],
             mdata['fp_resources'],

--- a/dpgen/generator/lib/lammps.py
+++ b/dpgen/generator/lib/lammps.py
@@ -4,7 +4,7 @@ import random, os, sys, dpdata
 import numpy as np
 import subprocess as sp
 import scipy.constants as pc
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 def _sample_sphere() :
     while True:
@@ -33,7 +33,7 @@ def make_lammps_input(ensemble,
                       max_seed = 1000000,
                       nopbc = False,
                       deepmd_version = '0.1') :
-    if (ele_temp_f is not None or ele_temp_a is not None) and LooseVersion(deepmd_version) < LooseVersion('1'):
+    if (ele_temp_f is not None or ele_temp_a is not None) and Version(deepmd_version) < Version('1'):
         raise RuntimeError('the electron temperature is only supported by deepmd-kit >= 1.0.0, please upgrade your deepmd-kit')
     if ele_temp_f is not None and ele_temp_a is not None:
         raise RuntimeError('the frame style ele_temp and atom style ele_temp should not be set at the same time')
@@ -68,7 +68,7 @@ def make_lammps_input(ensemble,
     graph_list = ""
     for ii in graphs :
         graph_list += ii + " "
-    if LooseVersion(deepmd_version) < LooseVersion('1'):
+    if Version(deepmd_version) < Version('1'):
         # 0.x
         ret+= "pair_style      deepmd %s ${THERMO_FREQ} model_devi.out\n" % graph_list
     else:

--- a/dpgen/generator/lib/run_calypso.py
+++ b/dpgen/generator/lib/run_calypso.py
@@ -19,7 +19,7 @@ from ase.io.vasp import write_vasp
 from ase.io.trajectory import Trajectory
 from pathlib import Path
 from itertools import combinations
-from distutils.version import LooseVersion
+from packaging.version import Version
 from dpgen import dlog
 from dpgen.generator.lib.utils import create_path
 from dpgen.generator.lib.utils import make_iter_name
@@ -122,7 +122,7 @@ def gen_structures(iter_index, jdata, mdata, caly_run_path, current_idx, length_
 
             run_tasks = [os.path.basename(ii) for ii in run_tasks_]
 
-            if LooseVersion(api_version) < LooseVersion('1.0'):
+            if Version(api_version) < Version('1.0'):
                 warnings.warn(f"the dpdispatcher will be updated to new version."
                     f"And the interface may be changed. Please check the documents for more details")
                 dispatcher=make_dispatcher(mdata['model_devi_machine'],mdata['model_devi_resources'],'./', run_tasks, model_devi_group_size)
@@ -136,7 +136,7 @@ def gen_structures(iter_index, jdata, mdata, caly_run_path, current_idx, length_
                                 backward_files,
                                 outlog = 'model_devi.log',
                                 errlog = 'model_devi.log')
-            elif LooseVersion(api_version) >= LooseVersion('1.0'):
+            elif Version(api_version) >= Version('1.0'):
                 os.chdir(cwd)
                 submission = make_submission(
                     mdata['model_devi_machine'],
@@ -169,7 +169,7 @@ def gen_structures(iter_index, jdata, mdata, caly_run_path, current_idx, length_
                 # to traj
                 shutil.copyfile(os.path.join('task.%03d'%(jjj),'traj.traj'),os.path.join('traj','%s.traj'%str(jjj+1)),)
 
-            if LooseVersion(api_version) < LooseVersion('1.0'):
+            if Version(api_version) < Version('1.0'):
                 os.rename('jr.json','jr_%s.json'%(str(ii)))
 
             tlist = glob.glob('task.*')
@@ -232,7 +232,7 @@ def gen_structures(iter_index, jdata, mdata, caly_run_path, current_idx, length_
 
         run_tasks = [os.path.basename(ii) for ii in run_tasks_]
 
-        if LooseVersion(api_version) < LooseVersion('1.0'):
+        if Version(api_version) < Version('1.0'):
             warnings.warn(f"the dpdispatcher will be updated to new version."
                 f"And the interface may be changed. Please check the documents for more details")
             dispatcher=make_dispatcher(mdata['model_devi_machine'],mdata['model_devi_resources'],'./', run_tasks, model_devi_group_size)
@@ -246,7 +246,7 @@ def gen_structures(iter_index, jdata, mdata, caly_run_path, current_idx, length_
                             backward_files,
                             outlog = 'model_devi.log',
                             errlog = 'model_devi.log')
-        elif LooseVersion(api_version) >= LooseVersion('1.0'):
+        elif Version(api_version) >= Version('1.0'):
             os.chdir(cwd)
             submission = make_submission(
                 mdata['model_devi_machine'],

--- a/dpgen/remote/decide_machine.py
+++ b/dpgen/remote/decide_machine.py
@@ -9,7 +9,7 @@ from dpgen import dlog
 import os
 import json
 import numpy as np
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 
 def convert_mdata(mdata, task_types=["train", "model_devi", "fp"]):
@@ -54,7 +54,7 @@ def convert_mdata(mdata, task_types=["train", "model_devi", "fp"]):
 
 
 # def decide_train_machine(mdata):
-# 	if LooseVersion(mdata.get('api_version', '0.9')) >= LooseVersion('1.0'):
+# 	if Version(mdata.get('api_version', '0.9')) >= Version('1.0'):
 # 		mdata['train_group_size'] = mdata['train'][0]['resources']['group_size']
 # 	if 'train' in mdata:
 # 		continue_flag = False
@@ -173,7 +173,7 @@ def convert_mdata(mdata, task_types=["train", "model_devi", "fp"]):
 # 	return mdata
 #
 # def decide_model_devi_machine(mdata):
-# 	if LooseVersion(mdata.get('api_version', '0.9')) >= LooseVersion('1.0'):
+# 	if Version(mdata.get('api_version', '0.9')) >= Version('1.0'):
 # 		mdata['model_devi_group_size'] = mdata['model_devi'][0]['resources']['group_size']
 # 	if 'model_devi' in mdata:
 # 		continue_flag = False
@@ -251,7 +251,7 @@ def convert_mdata(mdata, task_types=["train", "model_devi", "fp"]):
 # 				json.dump(profile, _outfile, indent = 4)
 # 	return mdata
 # def decide_fp_machine(mdata):
-# 	if LooseVersion(mdata.get('api_version', '0.9')) >= LooseVersion('1.0'):
+# 	if Version(mdata.get('api_version', '0.9')) >= Version('1.0'):
 # 		mdata['fp_group_size'] = mdata['fp'][0]['resources']['group_size']
 # 	if 'fp' in mdata:
 # 		#ssert isinstance(mdata['fp']['machine'], list)

--- a/dpgen/simplify/simplify.py
+++ b/dpgen/simplify/simplify.py
@@ -24,7 +24,7 @@ from typing import Union, List
 from dpgen import dlog
 from dpgen import SHORT_CMD
 from dpgen.util import sepline, expand_sys_str, normalize
-from distutils.version import LooseVersion
+from packaging.version import Version
 from dpgen.dispatcher.Dispatcher import Dispatcher, _split_tasks, make_dispatcher, make_submission
 from dpgen.generator.run import make_train, run_train, post_train, run_fp, post_fp, fp_name, model_devi_name, train_name, train_task_fmt, sys_link_fp_vasp_pp, make_fp_vasp_incar, make_fp_vasp_kp, make_fp_vasp_cp_cvasp, data_system_fmt, model_devi_task_fmt, fp_task_fmt
 # TODO: maybe the following functions can be moved to dpgen.util
@@ -202,7 +202,7 @@ def run_model_devi(iter_index, jdata, mdata):
     backward_files = [detail_file_name]
 
     api_version = mdata.get('api_version', '0.9')
-    if LooseVersion(api_version) < LooseVersion('1.0'):
+    if Version(api_version) < Version('1.0'):
         warnings.warn(f"the dpdispatcher will be updated to new version."
             f"And the interface may be changed. Please check the documents for more details")
         dispatcher = make_dispatcher(mdata['model_devi_machine'], mdata['model_devi_resources'], work_path, run_tasks, model_devi_group_size)
@@ -217,7 +217,7 @@ def run_model_devi(iter_index, jdata, mdata):
                         outlog = 'model_devi.log',
                         errlog = 'model_devi.log')
 
-    elif LooseVersion(api_version) >= LooseVersion('1.0'):
+    elif Version(api_version) >= Version('1.0'):
         submission = make_submission(
             mdata['model_devi_machine'],
             mdata['model_devi_resources'],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     'h5py',
     'pymatgen-analysis-defects',
     'openbabel-wheel',
+    'packaging',
 ]
 requires-python = ">=3.8"
 readme = "README.md"


### PR DESCRIPTION
`distutils` will be removed from Python 3.12. See [PEP 632](https://peps.python.org/pep-0632/).

Signed-off-by: Jinzhe Zeng <jinzhe.zeng@rutgers.edu>