### PR TITLE
fix_bug simplify.py

### DIFF
--- a/dpgen/simplify/simplify.py
+++ b/dpgen/simplify/simplify.py
@@ -317,7 +317,7 @@ def make_fp_labeled(iter_index, jdata):
     create_path(work_path)
     picked_data_path = os.path.join(iter_name, model_devi_name, picked_data_name)
     os.symlink(os.path.abspath(picked_data_path), os.path.abspath(
-        os.path.join(work_path, "task." + fp_task_fmt % 0)))
+        os.path.join(work_path, "task." + fp_task_fmt % (0,0))))
     os.symlink(os.path.abspath(picked_data_path), os.path.abspath(
         os.path.join(work_path, "data." + data_system_fmt % 0)))
 

--- a/dpgen/simplify/simplify.py
+++ b/dpgen/simplify/simplify.py
@@ -317,7 +317,7 @@ def make_fp_labeled(iter_index, jdata):
     create_path(work_path)
     picked_data_path = os.path.join(iter_name, model_devi_name, picked_data_name)
     os.symlink(os.path.abspath(picked_data_path), os.path.abspath(
-        os.path.join(work_path, "task." + data_system_fmt % 0)))
+        os.path.join(work_path, "task." + fp_task_fmt % 0)))
     os.symlink(os.path.abspath(picked_data_path), os.path.abspath(
         os.path.join(work_path, "data." + data_system_fmt % 0)))
 


### PR DESCRIPTION
**expected behavior**:
when `"labeled":true` in `dpgen simplify`, 02.fp will soft-link "labeled data", and the soft-linked "task dir" will also be created, for format consistency.

it is expected to be `data.000` and `task.000.000000`, 
being respectively guaranteed by funcs `data_system_fmt` and `fp_task_fmt`

**bug**:
the typo_bug used `data_system_fmt` for the "task dir" instead of `fp_task_fmt`,
then gives `task.000` instead of `task.000.000000`,

which makes `_check_empty_iter` (who checks `glob.glog("task.000.*")`) in `generator/run.py` sentence this iter empty,
then `00.train` of the next iter is always skipped.

**consequence**:
this make the "simplify_labeled" process never starts correctly, 

no iter0 model presents and randomly-picked data in iter0 are never trained, 
then iter1 gives error that can't finding the graph file from iter0 when trying copying them due to the train-skip.

**BTW**
thought "simplify_labeled" valuable in some complex or big-data scenarios but seems not loved by users yet.
pity  : (

Signed-off-by: Wanrun Jiang <58099845+Vibsteamer@users.noreply.github.com>