### PR TITLE
Raise warnings if there is no system in the path listed in sys_configs

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -1004,7 +1004,10 @@ def make_model_devi(iter_index, jdata, mdata):
         cur_systems = []
         ss = sys_configs[idx]
         for ii in ss:
-            cur_systems += sorted(glob.glob(ii))
+            ii_systems = sorted(glob.glob(ii))
+            if ii_systems == []:
+                warnings.warn("There is no system in the path %s. Please check if the path is correct." % ii)
+            cur_systems += ii_systems
         # cur_systems should not be sorted, as we may add specific constrict to the similutions
         # cur_systems.sort()
         cur_systems = [os.path.abspath(ii) for ii in cur_systems]

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -1003,11 +1003,12 @@ def make_model_devi(iter_index, jdata, mdata):
     for idx in sys_idx:
         cur_systems = []
         ss = sys_configs[idx]
-        for ii in ss:            
+        for ii in ss:
             ii_systems = sorted(glob.glob(ii))
             if ii_systems == []:
                 warnings.warn(
-                    "There is no system in the path %s. Please check if the path is correct." % ii
+                    "There is no system in the path %s. Please check if the path is correct."
+                    % ii
                 )
             cur_systems += ii_systems
         # cur_systems should not be sorted, as we may add specific constrict to the similutions

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -1004,10 +1004,7 @@ def make_model_devi(iter_index, jdata, mdata):
         cur_systems = []
         ss = sys_configs[idx]
         for ii in ss:
-            ii_systems = sorted(glob.glob(ii))
-            if ii_systems == []:
-                warnings.warn("There is no system in the path %s. Please check if the path is correct." % ii)
-            cur_systems += ii_systems
+            cur_systems += sorted(glob.glob(ii))
         # cur_systems should not be sorted, as we may add specific constrict to the similutions
         # cur_systems.sort()
         cur_systems = [os.path.abspath(ii) for ii in cur_systems]


### PR DESCRIPTION
If the user writes a wrong path in "sys_configs", this warning can help locate the problem.