### PR TITLE
bug_fix reproduce.py

### DIFF
--- a/dpgen/auto_test/reproduce.py
+++ b/dpgen/auto_test/reproduce.py
@@ -139,7 +139,7 @@ def post_repro(
         else:
             nframe = len(init_task_result["energies"])
         # idid += nframe
-        natoms = init_task_result["atom_numbs"][0]
+        natoms = np.sum(init_task_result["atom_numbs"])
         if reprod_last_frame:
             init_ener = init_task_result["energies"][-1:]
         else:


### PR DESCRIPTION
previous natoms only count #atom of the first element, gives wrong results or -inf in multiple-element cases