### PR TITLE
fix a bug in `convert_training_data_to_hdf5`

### DIFF
--- a/dpgen/util.py
+++ b/dpgen/util.py
@@ -125,7 +125,7 @@ def convert_training_data_to_hdf5(input_files: List[str], h5_file: str):
                     p1, p2 = pp.split("#")
                     ff = os.path.normpath(str((dd / p1).absolute().relative_to(cwd)))
                     pp = ff + "#" + p2
-                    new_pp = os.path.normpath(os.path.relpath(ff, h5_dir)) + "/" + p2
+                    new_pp = os.path.normpath(os.path.relpath(ff, h5_dir)) + p2
                 else:
                     pp = os.path.normpath(str((dd / pp).absolute().relative_to(cwd)))
                     new_pp = os.path.normpath(os.path.relpath(pp, h5_dir))
@@ -144,7 +144,7 @@ def convert_training_data_to_hdf5(input_files: List[str], h5_file: str):
             if "#" in ii:
                 p1, p2 = ii.split("#")
                 p1 = os.path.normpath(os.path.relpath(p1, h5_dir))
-                group = f.create_group(str(p1) + "/" + p2)
+                group = f.create_group(str(p1) + p2)
                 s = dpdata.LabeledSystem(ii, fmt="deepmd/hdf5")
                 s.to("deepmd/hdf5", group)
             else:

--- a/tests/generator/test_make_train.py
+++ b/tests/generator/test_make_train.py
@@ -491,7 +491,7 @@ class TestMakeTrain(unittest.TestCase):
             jdata0["training"]["systems"],
             [
                 "../data.hdf5#/data.init/deepmd",
-                "../data.hdf5#/data.init/deepmd.hdf5/",
+                "../data.hdf5#/data.init/deepmd.hdf5",
                 "../data.hdf5#/data.iters/iter.000000/02.fp/data.000",
             ],
         )


### PR DESCRIPTION
In this method, `p2` has been started with `/` so no `/` should be added again.