### PR TITLE
support `mixed:N` batch size

### DIFF
--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -38,10 +38,10 @@ def data_args() -> List[Argument]:
     doc_init_data_prefix = "Prefix of initial data directories."
     doc_init_data_sys = "Paths of initial data. The path can be either a system diretory containing NumPy files or an HDF5 file. You may use either absolute or relative path here. Systems will be detected recursively in the directories or the HDF5 file."
     doc_sys_format = "Format of sys_configs."
-    doc_init_batch_size = "Each number is the batch_size of corresponding system for training in init_data_sys. One recommended rule for setting the sys_batch_size and init_batch_size is that batch_size mutiply number of atoms ot the stucture should be larger than 32. If set to auto, batch size will be 32 divided by number of atoms."
+    doc_init_batch_size = "Each number is the batch_size of corresponding system for training in init_data_sys. One recommended rule for setting the sys_batch_size and init_batch_size is that batch_size mutiply number of atoms ot the stucture should be larger than 32. If set to auto, batch size will be 32 divided by number of atoms. This argument only works when the batch size is not given in `default_training_param`."
     doc_sys_configs_prefix = "Prefix of sys_configs."
     doc_sys_configs = "Containing directories of structures to be explored in iterations.Wildcard characters are supported here."
-    doc_sys_batch_size = "Each number is the batch_size for training of corresponding system in sys_configs. If set to auto, batch size will be 32 divided by number of atoms."
+    doc_sys_batch_size = "Each number is the batch_size for training of corresponding system in sys_configs. If set to auto, batch size will be 32 divided by number of atoms. This argument only works when the batch size is not given in `default_training_param`."
 
     return [
         Argument("init_data_prefix", str, optional=True, doc=doc_init_data_prefix),

--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -38,10 +38,10 @@ def data_args() -> List[Argument]:
     doc_init_data_prefix = "Prefix of initial data directories."
     doc_init_data_sys = "Paths of initial data. The path can be either a system diretory containing NumPy files or an HDF5 file. You may use either absolute or relative path here. Systems will be detected recursively in the directories or the HDF5 file."
     doc_sys_format = "Format of sys_configs."
-    doc_init_batch_size = "Each number is the batch_size of corresponding system for training in init_data_sys. One recommended rule for setting the sys_batch_size and init_batch_size is that batch_size mutiply number of atoms ot the stucture should be larger than 32. If set to auto, batch size will be 32 divided by number of atoms. This argument only works when the batch size is not given in `default_training_param`."
+    doc_init_batch_size = "Each number is the batch_size of corresponding system for training in init_data_sys. One recommended rule for setting the sys_batch_size and init_batch_size is that batch_size mutiply number of atoms ot the stucture should be larger than 32. If set to auto, batch size will be 32 divided by number of atoms. This argument will not override the mixed batch size in `default_training_param`."
     doc_sys_configs_prefix = "Prefix of sys_configs."
     doc_sys_configs = "Containing directories of structures to be explored in iterations.Wildcard characters are supported here."
-    doc_sys_batch_size = "Each number is the batch_size for training of corresponding system in sys_configs. If set to auto, batch size will be 32 divided by number of atoms. This argument only works when the batch size is not given in `default_training_param`."
+    doc_sys_batch_size = "Each number is the batch_size for training of corresponding system in sys_configs. If set to auto, batch size will be 32 divided by number of atoms. This argument will not override the mixed batch size in `default_training_param`."
 
     return [
         Argument("init_data_prefix", str, optional=True, doc=doc_init_data_prefix),

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -408,7 +408,7 @@ def make_train(iter_index, jdata, mdata):
     ) < Version("2"):
         # 1.x
         jinput["training"]["systems"] = init_data_sys
-        jinput["training"].setdefault("batch_size", init_batch_size)
+        jinput["training"]["batch_size"] = init_batch_size
         jinput["model"]["type_map"] = jdata["type_map"]
         # electron temperature
         if use_ele_temp == 0:
@@ -427,7 +427,9 @@ def make_train(iter_index, jdata, mdata):
         # 2.x
         jinput["training"].setdefault("training_data", {})
         jinput["training"]["training_data"]["systems"] = init_data_sys
-        jinput["training"]["training_data"].setdefault("batch_size", init_batch_size)
+        old_batch_size = jinput["training"]["training_data"].get("batch_size", "")
+        if not (isinstance(old_batch_size, str) and old_batch_size.startswith("mixed:")):
+            jinput["training"]["training_data"]["batch_size"] = init_batch_size
         jinput["model"]["type_map"] = jdata["type_map"]
         # electron temperature
         if use_ele_temp == 0:

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -428,7 +428,9 @@ def make_train(iter_index, jdata, mdata):
         jinput["training"].setdefault("training_data", {})
         jinput["training"]["training_data"]["systems"] = init_data_sys
         old_batch_size = jinput["training"]["training_data"].get("batch_size", "")
-        if not (isinstance(old_batch_size, str) and old_batch_size.startswith("mixed:")):
+        if not (
+            isinstance(old_batch_size, str) and old_batch_size.startswith("mixed:")
+        ):
             jinput["training"]["training_data"]["batch_size"] = init_batch_size
         jinput["model"]["type_map"] = jdata["type_map"]
         # electron temperature

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -408,7 +408,7 @@ def make_train(iter_index, jdata, mdata):
     ) < Version("2"):
         # 1.x
         jinput["training"]["systems"] = init_data_sys
-        jinput["training"]["batch_size"] = init_batch_size
+        jinput["training"].setdefault("batch_size", init_batch_size)
         jinput["model"]["type_map"] = jdata["type_map"]
         # electron temperature
         if use_ele_temp == 0:
@@ -425,9 +425,9 @@ def make_train(iter_index, jdata, mdata):
         mdata["deepmd_version"]
     ) < Version("3"):
         # 2.x
-        jinput["training"]["training_data"] = {}
+        jinput["training"].setdefault("training_data", {})
         jinput["training"]["training_data"]["systems"] = init_data_sys
-        jinput["training"]["training_data"]["batch_size"] = init_batch_size
+        jinput["training"]["training_data"].setdefault("batch_size", init_batch_size)
         jinput["model"]["type_map"] = jdata["type_map"]
         # electron temperature
         if use_ele_temp == 0:


### PR DESCRIPTION
This allows setting batches of mixed systems, i.e. `mixed:N`, without being overridden by DP-GEN.

P.S. now `mixed:N` does work in my systems.