### PR TITLE
fix batch size for simplify

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -393,8 +393,11 @@ def make_train(iter_index, jdata, mdata):
                     init_data_sys.append(
                         os.path.normpath(os.path.join("..", "data.iters", sys_single))
                     )
+                    batch_size = sys_batch_size[sys_idx] if sys_idx < len(
+                        sys_batch_size
+                    ) else "auto"
                     init_batch_size.append(
-                        detect_batch_size(sys_batch_size[sys_idx], sys_single)
+                        detect_batch_size(batch_size, sys_single)
                     )
     # establish tasks
     jinput = jdata["default_training_param"]

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -393,12 +393,12 @@ def make_train(iter_index, jdata, mdata):
                     init_data_sys.append(
                         os.path.normpath(os.path.join("..", "data.iters", sys_single))
                     )
-                    batch_size = sys_batch_size[sys_idx] if sys_idx < len(
-                        sys_batch_size
-                    ) else "auto"
-                    init_batch_size.append(
-                        detect_batch_size(batch_size, sys_single)
+                    batch_size = (
+                        sys_batch_size[sys_idx]
+                        if sys_idx < len(sys_batch_size)
+                        else "auto"
                     )
+                    init_batch_size.append(detect_batch_size(batch_size, sys_single))
     # establish tasks
     jinput = jdata["default_training_param"]
     try:


### PR DESCRIPTION
#803 changed the behavior of sys_idx in the fp step and caused there to be lots of systems. However, it failed to try to get the batch size of these systems.