### PR TITLE
simplify: do not symlink if the file does not exist

### DIFF
--- a/dpgen/simplify/simplify.py
+++ b/dpgen/simplify/simplify.py
@@ -394,6 +394,8 @@ def make_fp_configs(iter_index, jdata):
     work_path = os.path.join(iter_name, fp_name)
     create_path(work_path)
     picked_data_path = os.path.join(iter_name, model_devi_name, picked_data_name)
+    if not os.path.exists(os.path.abspath(picked_data_path)):
+        return
     systems = get_multi_system(picked_data_path, jdata)
     ii = 0
     jj = 0

--- a/dpgen/simplify/simplify.py
+++ b/dpgen/simplify/simplify.py
@@ -377,7 +377,7 @@ def make_fp_labeled(iter_index, jdata):
     work_path = os.path.join(iter_name, fp_name)
     create_path(work_path)
     picked_data_path = os.path.join(iter_name, model_devi_name, picked_data_name)
-    if os.exists(os.path.abspath(picked_data_path)):
+    if os.path.exists(os.path.abspath(picked_data_path)):
         os.symlink(
             os.path.abspath(picked_data_path),
             os.path.abspath(os.path.join(work_path, "task." + fp_task_fmt % (0, 0))),

--- a/dpgen/simplify/simplify.py
+++ b/dpgen/simplify/simplify.py
@@ -377,14 +377,15 @@ def make_fp_labeled(iter_index, jdata):
     work_path = os.path.join(iter_name, fp_name)
     create_path(work_path)
     picked_data_path = os.path.join(iter_name, model_devi_name, picked_data_name)
-    os.symlink(
-        os.path.abspath(picked_data_path),
-        os.path.abspath(os.path.join(work_path, "task." + fp_task_fmt % (0, 0))),
-    )
-    os.symlink(
-        os.path.abspath(picked_data_path),
-        os.path.abspath(os.path.join(work_path, "data." + data_system_fmt % 0)),
-    )
+    if os.exists(os.path.abspath(picked_data_path)):
+        os.symlink(
+            os.path.abspath(picked_data_path),
+            os.path.abspath(os.path.join(work_path, "task." + fp_task_fmt % (0, 0))),
+        )
+        os.symlink(
+            os.path.abspath(picked_data_path),
+            os.path.abspath(os.path.join(work_path, "data." + data_system_fmt % 0)),
+        )
 
 
 def make_fp_configs(iter_index, jdata):


### PR DESCRIPTION
If there is no candidate (i.e. all accurate or all failed), `picked_data_path` will not be dumped.