### PR TITLE
refactor(abacus): modify poscar2stru in auto_test.lib.abacus

### DIFF
--- a/dpgen/auto_test/lib/abacus.py
+++ b/dpgen/auto_test/lib/abacus.py
@@ -5,14 +5,12 @@ from unicodedata import numeric
 
 import dpdata
 import numpy as np
+from dpdata.abacus.scf import make_unlabeled_stru
+from dpdata.utils import uniq_atom_names
+from dpdata.vasp import poscar as dpdata_poscar
 from pymatgen.core.structure import Structure
 
 import dpgen.generator.lib.abacus_scf as abacus_scf
-
-from dpdata.vasp import poscar as dpdata_poscar 
-from dpdata.utils import uniq_atom_names
-
-from dpdata.abacus.scf import make_unlabeled_stru
 
 A2BOHR = 1.8897261254578281
 MASS_DICT = {
@@ -257,9 +255,9 @@ def poscar2stru(poscar, inter_param, stru="STRU"):
                             - deepks_desc:  a string of deepks descriptor file
     - stru:            output filename, usally is 'STRU'
     """
-    #if use dpdata.System, the structure will be rotated to make cell to be lower triangular
+    # if use dpdata.System, the structure will be rotated to make cell to be lower triangular
     with open(poscar) as fp:
-            lines = [line.rstrip("\n") for line in fp]
+        lines = [line.rstrip("\n") for line in fp]
     stru_data = dpdata_poscar.to_system_data(lines)
     stru_data = uniq_atom_names(stru_data)
 
@@ -301,13 +299,13 @@ def poscar2stru(poscar, inter_param, stru="STRU"):
         deepks_desc = "./pp_orb/%s\n" % inter_param["deepks_desc"]
 
     stru_string = make_unlabeled_stru(
-            data=stru_data,
-            frame_idx=0,
-            pp_file=pseudo,
-            numerical_orbital=orb,
-            numerical_descriptor=deepks_desc,
-            mass=atom_mass,
-        )
+        data=stru_data,
+        frame_idx=0,
+        pp_file=pseudo,
+        numerical_orbital=orb,
+        numerical_descriptor=deepks_desc,
+        mass=atom_mass,
+    )
     with open(stru, "w") as fp:
         fp.write(stru_string)
 


### PR DESCRIPTION
Original function `poscar2stru()` use dpdata.System to read POSCAR, but it will rotate the structure to make cell to be lower triangular, and this rotation is unexpected.