### PR TITLE
split make_fp and share `make_fp_calculation` between run and simplify

### DIFF
--- a/dpgen/simplify/arginfo.py
+++ b/dpgen/simplify/arginfo.py
@@ -6,7 +6,10 @@ from dpgen.arginfo import general_mdata_arginfo
 from dpgen.generator.arginfo import (
     basic_args,
     data_args,
+    fp_style_abacus_args,
+    fp_style_cp2k_args,
     fp_style_gaussian_args,
+    fp_style_siesta_args,
     fp_style_vasp_args,
     training_args,
 )
@@ -59,7 +62,7 @@ def fp_style_variant_type_args() -> Variant:
     Variant
         variant for fp style
     """
-    doc_fp_style = "Software for First Principles, if `labeled` is false. Options include “vasp”, “gaussian” up to now."
+    doc_fp_style = "Software for First Principles, if `labeled` is false."
     doc_fp_style_none = "No fp."
     doc_fp_style_vasp = "VASP."
     doc_fp_style_gaussian = "Gaussian. The command should be set as `g16 < input`."
@@ -73,6 +76,15 @@ def fp_style_variant_type_args() -> Variant:
             Argument(
                 "gaussian", dict, fp_style_gaussian_args(), doc=doc_fp_style_gaussian
             ),
+            Argument("siesta", dict, fp_style_siesta_args()),
+            Argument("cp2k", dict, fp_style_cp2k_args()),
+            Argument("abacus", dict, fp_style_abacus_args()),
+            # TODO: not supported yet, as it requires model_devi_engine to be amber
+            # Argument(
+            #     "amber/diff", dict, fp_style_amber_diff_args(), doc=doc_amber_diff
+            # ),
+            Argument("pwmat", dict, [], doc="TODO: add doc"),
+            Argument("pwscf", dict, [], doc="TODO: add doc"),
         ],
         optional=True,
         default_tag="none",

--- a/dpgen/simplify/simplify.py
+++ b/dpgen/simplify/simplify.py
@@ -422,10 +422,6 @@ def make_fp(iter_index, jdata, mdata):
         make_fp_configs(iter_index, jdata)
         jdata["model_devi_engine"] = "lammps"
         make_fp_calculation(iter_index, jdata, mdata)
-        # Copy user defined forward_files
-        iter_name = make_iter_name(iter_index)
-        work_path = os.path.join(iter_name, fp_name)
-        symlink_user_forward_files(mdata=mdata, task_type="fp", work_path=work_path)
 
 
 def run_iter(param_file, machine_file):

--- a/tests/generator/test_gromacs_engine.py
+++ b/tests/generator/test_gromacs_engine.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 __package__ = "generator"
 dirname = os.path.join(os.path.abspath(os.path.dirname(__file__)), "gromacs")
 
-from .context import make_fp_gaussian, make_model_devi
+from .context import make_fp, make_model_devi
 
 
 def _make_fake_graphs(train_path):
@@ -131,7 +131,7 @@ class TestGromacsModelDeviEngine(unittest.TestCase):
         self._copy_outputs(
             os.path.join(self.dirname, "outputs"), self.model_devi_task_path
         )
-        make_fp_gaussian(iter_index=0, jdata=self.jdata)
+        make_fp(iter_index=0, jdata=self.jdata, mdata={})
         candi = np.loadtxt(
             os.path.join(self.fp_path, "candidate.shuffled.000.out"), dtype=str
         )


### PR DESCRIPTION
Fix #1222.

Currently, `make_fp` does two things: (1) select candidates from the model_devi task; (2) make FP input file. They are in the same method. This commit splits the method into two independent methods, `make_fp_configs` and `make_fp_calculation`. Run and simplify have their own `make_fp_configs`, but share the same `make_fp_calculation`.

The existing problem is that `make_fp_configs` generates different formats for different model_devi_engine. (e.g., POSCAR for lammps) We should resolve this problem in the future.