### PR TITLE
docs: move ·ratio_failed· out of fp variant

### DIFF
--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -550,7 +550,6 @@ def fp_style_vasp_args() -> List[Argument]:
     doc_cvasp = (
         "If cvasp is true, DP-GEN will use Custodian to help control VASP calculation."
     )
-    doc_ratio_failed = "Check the ratio of unsuccessfully terminated jobs. If too many FP tasks are not converged, RuntimeError will be raised."
     doc_fp_skip_bad_box = (
         "Skip the configurations that are obviously unreasonable before 02.fp"
     )
@@ -561,7 +560,6 @@ def fp_style_vasp_args() -> List[Argument]:
         Argument("fp_incar", str, optional=False, doc=doc_fp_incar),
         Argument("fp_aniso_kspacing", list, optional=True, doc=doc_fp_aniso_kspacing),
         Argument("cvasp", bool, optional=True, doc=doc_cvasp),
-        Argument("ratio_failed", float, optional=True, doc=doc_ratio_failed),
         Argument("fp_skip_bad_box", str, optional=True, doc=doc_fp_skip_bad_box),
     ]
 
@@ -662,7 +660,6 @@ def fp_style_gaussian_args() -> List[Argument]:
         "kept. In this case, other atoms out of the soft cutoff radius will be removed."
     )
     doc_fp_params_gaussian = "Parameters for Gaussian calculation."
-    doc_ratio_failed = "Check the ratio of unsuccessfully terminated jobs. If too many FP tasks are not converged, RuntimeError will be raised."
 
     return [
         Argument(
@@ -678,7 +675,6 @@ def fp_style_gaussian_args() -> List[Argument]:
         Argument(
             "fp_params", dict, args, [], optional=False, doc=doc_fp_params_gaussian
         ),
-        Argument("ratio_failed", float, optional=True, doc=doc_ratio_failed),
     ]
 
 
@@ -735,7 +731,6 @@ def fp_style_cp2k_args() -> List[Argument]:
         "      &END PRINT\n"
         "\n"
     )
-    doc_ratio_failed = "Check the ratio of unsuccessfully terminated jobs. If too many FP tasks are not converged, RuntimeError will be raised."
 
     return [
         Argument(
@@ -748,7 +743,6 @@ def fp_style_cp2k_args() -> List[Argument]:
         Argument(
             "external_input_path", str, optional=True, doc=doc_external_input_path
         ),
-        Argument("ratio_failed", float, optional=True, doc=doc_ratio_failed),
     ]
 
 
@@ -827,6 +821,7 @@ def fp_args() -> List[Argument]:
     doc_detailed_report_make_fp = (
         "If set to true, detailed report will be generated for each iteration."
     )
+    doc_ratio_failed = "Check the ratio of unsuccessfully terminated jobs. If too many FP tasks are not converged, RuntimeError will be raised."
 
     return [
         Argument("fp_task_max", int, optional=False, doc=doc_fp_task_max),
@@ -848,6 +843,7 @@ def fp_args() -> List[Argument]:
             default=True,
             doc=doc_detailed_report_make_fp,
         ),
+        Argument("ratio_failed", float, optional=True, doc=doc_ratio_failed),
     ]
 
 


### PR DESCRIPTION
The current implementation of `ratio_failed` is available and shared for all fp styles. Thus, this argument should move out of any specific fp variant in the documentation.