### PR TITLE
Use get_global_number_of_atoms() instead

### DIFF
--- a/dpgen/data/tools/create_random_disturb.py
+++ b/dpgen/data/tools/create_random_disturb.py
@@ -54,7 +54,7 @@ def create_disturbs_ase(
 
     # read-in by ase
     atoms = ase.io.read(fin)
-    natoms = atoms.get_number_of_atoms()
+    natoms = atoms.get_global_number_of_atoms()
     pos0 = atoms.get_positions()
 
     # creat nfile ofmt files.
@@ -119,7 +119,7 @@ def create_disturbs_ase_dev(
 
     # read-in by ase
     atoms = ase.io.read(fin)
-    natoms = atoms.get_number_of_atoms()
+    natoms = atoms.get_global_number_of_atoms()
     cell0 = atoms.get_cell()
 
     # creat nfile ofmt files.
@@ -186,7 +186,7 @@ def create_disturbs_abacus_dev(
 
     # read-in by ase
     # atoms = ase.io.read(fin)
-    # natoms = atoms.get_number_of_atoms()
+    # natoms = atoms.get_global_number_of_atoms()
     # cell0 = atoms.get_cell()
 
     stru = get_abacus_STRU(fin)

--- a/dpgen/data/tools/io_lammps.py
+++ b/dpgen/data/tools/io_lammps.py
@@ -163,7 +163,7 @@ def ase2lammpsdata(atoms, typeids=None, fout="out.lmp"):
     fw.write("\n")
 
     # write number of atoms
-    natoms = atoms.get_number_of_atoms()
+    natoms = atoms.get_global_number_of_atoms()
     fw.write("%d atoms\n" % natoms)
     fw.write("\n")
 


### PR DESCRIPTION
```
/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/ase/atoms.py:967: VisibleDeprecationWarning: Use get_global_number_of_atoms() instead
```