### PR TITLE
drop Python 3.8 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       # See https://github.com/materialsproject/api/issues/809
-      run: pip install coverage pymatgen==2023.5.31 -e . 'mp-api<0.33; python_version < "3.9"'
+      run: pip install coverage pymatgen==2023.5.31 -e .
     - name: Test
       run: coverage run --source=./dpgen -m unittest -v && coverage report
     - uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.9", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Yuzhi Zhang, Haidi Wang, Weijie Chen, Jinzhe Zeng, Linfeng Zhang, Han Wang, and 
 
 ## Download and Install
 
-DP-GEN only supports Python 3.8 and above.
+DP-GEN only supports Python 3.9 and above.
 
 One can download the source code of dpgen by
 ```bash

--- a/conda/construct.yaml
+++ b/conda/construct.yaml
@@ -9,7 +9,7 @@ channels:
   - deepmodeling
 
 specs:
-  - python 3.8
+  - python 3.9
   - pip
   - dpgen {{ version }}
 

--- a/doc/overview/overview.md
+++ b/doc/overview/overview.md
@@ -21,7 +21,7 @@ Yuzhi Zhang, Haidi Wang, Weijie Chen, Jinzhe Zeng, Linfeng Zhang, Han Wang, and 
 
 ## Download and install
 
-DP-GEN only supports Python 3.8 and above.
+DP-GEN only supports Python 3.9 and above.
 
 Please follow our [GitHub](https://github.com/deepmodeling/dpgen) webpage to download the [latest released version](https://github.com/deepmodeling/dpgen/tree/master) and [development version](https://github.com/deepmodeling/dpgen/tree/devel).
 One can download the source code of dpgen by

--- a/dpgen/arginfo.py
+++ b/dpgen/arginfo.py
@@ -1,11 +1,11 @@
-from typing import Callable, Tuple
+from typing import Callable
 
 from dargs import Argument
 
 from dpgen.dispatcher.Dispatcher import mdata_arginfo
 
 
-def general_mdata_arginfo(name: str, tasks: Tuple[str]) -> Argument:
+def general_mdata_arginfo(name: str, tasks: tuple[str]) -> Argument:
     """Generate arginfo for general mdata.
 
     Parameters

--- a/dpgen/data/arginfo.py
+++ b/dpgen/data/arginfo.py
@@ -1,4 +1,3 @@
-from typing import List
 
 from dargs import Argument, Variant
 
@@ -38,11 +37,11 @@ def init_reaction_mdata_arginfo() -> Argument:
     return general_mdata_arginfo("init_reaction_mdata", ("reaxff", "build", "fp"))
 
 
-def init_bulk_vasp_args() -> List[Argument]:
+def init_bulk_vasp_args() -> list[Argument]:
     return []
 
 
-def init_bulk_abacus_args() -> List[Argument]:
+def init_bulk_abacus_args() -> list[Argument]:
     doc_relax_kpt = 'Path of `KPT` file for relaxation in stage 1. Only useful if `init_fp_style` is "ABACUS".'
     doc_md_kpt = 'Path of `KPT` file for MD simulations in stage 3. Only useful if `init_fp_style` is "ABACUS".'
     doc_atom_masses = 'List of atomic masses of elements. The order should be the same as `Elements`. Only useful if `init_fp_style` is "ABACUS".'
@@ -53,7 +52,7 @@ def init_bulk_abacus_args() -> List[Argument]:
     ]
 
 
-def init_bulk_variant_type_args() -> List[Variant]:
+def init_bulk_variant_type_args() -> list[Variant]:
     doc_init_fp_style = "First-principle software. If this key is absent."
     return [
         Variant(

--- a/dpgen/data/arginfo.py
+++ b/dpgen/data/arginfo.py
@@ -1,4 +1,3 @@
-
 from dargs import Argument, Variant
 
 from dpgen.arginfo import general_mdata_arginfo

--- a/dpgen/dispatcher/Dispatcher.py
+++ b/dpgen/dispatcher/Dispatcher.py
@@ -1,6 +1,5 @@
 import os
 from distutils.version import LooseVersion
-from typing import List
 
 # import dargs
 from dargs.dargs import Argument
@@ -56,7 +55,7 @@ def make_submission(
     return submission
 
 
-def mdata_arginfo() -> List[Argument]:
+def mdata_arginfo() -> list[Argument]:
     """This method generates arginfo for a single mdata.
 
     A submission requires the following keys: command, machine,
@@ -94,13 +93,13 @@ def mdata_arginfo() -> List[Argument]:
 def make_submission_compat(
     machine: dict,
     resources: dict,
-    commands: List[str],
+    commands: list[str],
     work_path: str,
-    run_tasks: List[str],
+    run_tasks: list[str],
     group_size: int,
-    forward_common_files: List[str],
-    forward_files: List[str],
-    backward_files: List[str],
+    forward_common_files: list[str],
+    forward_files: list[str],
+    backward_files: list[str],
     outlog: str = "log",
     errlog: str = "err",
     api_version: str = "1.0",

--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -1,5 +1,4 @@
 import textwrap
-from typing import List
 
 from dargs import Argument, Variant
 
@@ -18,7 +17,7 @@ def run_mdata_arginfo() -> Argument:
 
 
 # basics
-def basic_args() -> List[Argument]:
+def basic_args() -> list[Argument]:
     doc_type_map = "Atom types. Reminder: The elements in param.json, type.raw and data.lmp(when using lammps) should be in the same order."
     doc_mass_map = 'Standard atomic weights (default: "auto"). if one want to use isotopes, or non-standard element names, chemical symbols, or atomic number in the type_map list, please customize the mass_map list instead of using "auto".'
     doc_use_ele_temp = "Currently only support fp_style vasp. \n\n\
@@ -35,7 +34,7 @@ def basic_args() -> List[Argument]:
     ]
 
 
-def data_args() -> List[Argument]:
+def data_args() -> list[Argument]:
     doc_init_data_prefix = "Prefix of initial data directories."
     doc_init_data_sys = "Paths of initial data. The path can be either a system diretory containing NumPy files or an HDF5 file. You may use either absolute or relative path here. Systems will be detected recursively in the directories or the HDF5 file."
     doc_sys_format = "Format of sys_configs."
@@ -69,7 +68,7 @@ def data_args() -> List[Argument]:
 # Training
 
 
-def training_args() -> List[Argument]:
+def training_args() -> list[Argument]:
     """Traning arguments.
 
     Returns
@@ -226,7 +225,7 @@ def model_devi_jobs_rev_mat_args() -> Argument:
     )
 
 
-def model_devi_jobs_args() -> List[Argument]:
+def model_devi_jobs_args() -> list[Argument]:
     # this may be not correct
     doc_sys_rev_mat = (
         "system-resolved revise matrix for revising variable(s) defined in the template into specific values. "
@@ -292,7 +291,7 @@ def model_devi_jobs_args() -> List[Argument]:
     )
 
 
-def model_devi_lmp_args() -> List[Argument]:
+def model_devi_lmp_args() -> list[Argument]:
     doc_model_devi_dt = "Timestep for MD. 0.002 is recommend."
     doc_model_devi_skip = "Number of structures skipped for fp in each MD."
     doc_model_devi_f_trust_lo = "Lower bound of forces for the selection. If list or dict, should be set for each index in sys_configs, respectively."
@@ -438,7 +437,7 @@ The union of the two sets is made as candidate dataset."
     ]
 
 
-def model_devi_amber_args() -> List[Argument]:
+def model_devi_amber_args() -> list[Argument]:
     """Amber engine arguments."""
     doc_model_devi_jobs = (
         "List of dicts. The list including the dict for information of each cycle."
@@ -535,7 +534,7 @@ def model_devi_amber_args() -> List[Argument]:
     ]
 
 
-def model_devi_args() -> List[Variant]:
+def model_devi_args() -> list[Variant]:
     doc_model_devi_engine = "Engine for the model deviation task."
     doc_amber = "Amber DPRc engine. The command argument in the machine file should be path to sander."
     return [
@@ -556,7 +555,7 @@ def model_devi_args() -> List[Variant]:
 
 # Labeling
 # vasp
-def fp_style_vasp_args() -> List[Argument]:
+def fp_style_vasp_args() -> list[Argument]:
     doc_fp_pp_path = "Directory of psuedo-potential file to be used for 02.fp exists."
     doc_fp_pp_files = "Psuedo-potential file to be used for 02.fp. Note that the order of elements should correspond to the order in type_map."
     doc_fp_incar = "Input file for VASP. INCAR must specify KSPACING and KGAMMA."
@@ -579,7 +578,7 @@ def fp_style_vasp_args() -> List[Argument]:
 
 
 # abacus
-def fp_style_abacus_args() -> List[Argument]:
+def fp_style_abacus_args() -> list[Argument]:
     doc_fp_pp_path = "Directory of psuedo-potential or numerical orbital files to be used for 02.fp exists."
     doc_fp_pp_files = "Psuedo-potential file to be used for 02.fp. Note that the order of elements should correspond to the order in type_map."
     doc_fp_orb_files = "numerical orbital file to be used for 02.fp when using LCAO basis. Note that the order of elements should correspond to the order in type_map."
@@ -604,7 +603,7 @@ def fp_style_abacus_args() -> List[Argument]:
 
 
 # gaussian
-def fp_style_gaussian_args() -> List[Argument]:
+def fp_style_gaussian_args() -> list[Argument]:
     """Gaussian fp style arguments.
 
     Returns
@@ -693,7 +692,7 @@ def fp_style_gaussian_args() -> List[Argument]:
 
 
 # siesta
-def fp_style_siesta_args() -> List[Argument]:
+def fp_style_siesta_args() -> list[Argument]:
     doc_ecut = "Define the plane wave cutoff for grid."
     doc_ediff = "Tolerance of Density Matrix."
     doc_kspacing = "Sample factor in Brillouin zones."
@@ -726,7 +725,7 @@ def fp_style_siesta_args() -> List[Argument]:
 # cp2k
 
 
-def fp_style_cp2k_args() -> List[Argument]:
+def fp_style_cp2k_args() -> list[Argument]:
     doc_user_fp_params = "Parameters for cp2k calculation. find detail in manual.cp2k.org. only the kind section must be set before use. we assume that you have basic knowledge for cp2k input."
     doc_external_input_path = (
         "Conflict with key:user_fp_params.\n"
@@ -760,7 +759,7 @@ def fp_style_cp2k_args() -> List[Argument]:
     ]
 
 
-def fp_style_amber_diff_args() -> List[Argument]:
+def fp_style_amber_diff_args() -> list[Argument]:
     """Arguments for FP style amber/diff.
 
     Returns
@@ -797,7 +796,7 @@ def fp_style_amber_diff_args() -> List[Argument]:
     ]
 
 
-def fp_style_custom_args() -> List[Argument]:
+def fp_style_custom_args() -> list[Argument]:
     """Arguments for FP style custom.
 
     Returns
@@ -861,7 +860,7 @@ def fp_style_variant_type_args() -> Variant:
     )
 
 
-def fp_args() -> List[Argument]:
+def fp_args() -> list[Argument]:
     doc_fp_task_max = "Maximum number of structures to be calculated in each system in 02.fp of each iteration. If the number of candidate structures exceeds `fp_task_max`, `fp_task_max` structures will be randomly picked from the candidates and labeled."
     doc_fp_task_min = "Skip the training in the next iteration if the number of structures is no more than `fp_task_min`."
     doc_fp_accurate_threshold = "If the accurate ratio is larger than this number, no fp calculation will be performed, i.e. fp_task_max = 0."

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -24,7 +24,6 @@ import warnings
 from collections import Counter
 from collections.abc import Iterable
 from pathlib import Path
-from typing import List
 
 import dpdata
 import numpy as np
@@ -2089,7 +2088,7 @@ def _read_model_devi_file(
 
 
 def _select_by_model_devi_standard(
-    modd_system_task: List[str],
+    modd_system_task: list[str],
     f_trust_lo: float,
     f_trust_hi: float,
     v_trust_lo: float,
@@ -2192,7 +2191,7 @@ def _select_by_model_devi_standard(
 
 
 def _select_by_model_devi_adaptive_trust_low(
-    modd_system_task: List[str],
+    modd_system_task: list[str],
     f_trust_hi: float,
     numb_candi_f: int,
     perc_candi_f: float,

--- a/dpgen/simplify/arginfo.py
+++ b/dpgen/simplify/arginfo.py
@@ -1,4 +1,3 @@
-
 from dargs import Argument, Variant
 
 from dpgen.arginfo import general_mdata_arginfo

--- a/dpgen/simplify/arginfo.py
+++ b/dpgen/simplify/arginfo.py
@@ -1,4 +1,3 @@
-from typing import List
 
 from dargs import Argument, Variant
 
@@ -99,7 +98,7 @@ def fp_style_variant_type_args() -> Variant:
     )
 
 
-def fp_args() -> List[Argument]:
+def fp_args() -> list[Argument]:
     """Generate arginfo for fp.
 
     Returns

--- a/dpgen/simplify/simplify.py
+++ b/dpgen/simplify/simplify.py
@@ -13,7 +13,7 @@ import logging
 import os
 import queue
 from collections import defaultdict
-from typing import List, Union
+from typing import Union
 
 import dpdata
 import numpy as np
@@ -62,7 +62,7 @@ def get_system_cls(jdata):
     return dpdata.System
 
 
-def get_multi_system(path: Union[str, List[str]], jdata: dict) -> dpdata.MultiSystems:
+def get_multi_system(path: Union[str, list[str]], jdata: dict) -> dpdata.MultiSystems:
     """Get MultiSystems from a path or list of paths.
 
     Both NumPy and HDF5 formats are supported. For details

--- a/dpgen/util.py
+++ b/dpgen/util.py
@@ -5,7 +5,7 @@ from contextlib import (
     contextmanager,
 )
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 
 import dpdata
 import h5py
@@ -35,7 +35,7 @@ def box_center(ch="", fill=" ", sp="|"):
     dlog.info(sp + strs[1 : len(strs) - 1 :] + sp)
 
 
-def expand_sys_str(root_dir: Union[str, Path]) -> List[str]:
+def expand_sys_str(root_dir: Union[str, Path]) -> list[str]:
     """Recursively iterate over directories taking those that contain `type.raw` file.
 
     If root_dir is a file but not a directory, it will be assumed as an HDF5 file.
@@ -91,7 +91,7 @@ def normalize(arginfo: Argument, data: dict, strict_check: bool = True) -> dict:
     return data
 
 
-def convert_training_data_to_hdf5(input_files: List[str], h5_file: str):
+def convert_training_data_to_hdf5(input_files: list[str], h5_file: str):
     """Convert training data to HDF5 format and update the input files.
 
     Parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ authors = [
 ]
 license = {file = "LICENSE"}
 classifiers = [
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -35,7 +34,7 @@ dependencies = [
     'openbabel-wheel',
     'packaging',
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
 keywords = ["deep potential generator", "active learning", "deepmd-kit"]
 
@@ -57,7 +56,7 @@ write_to = "dpgen/_version.py"
 profile = "black"
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 select = [
     "I", # isort
     "E", # errors


### PR DESCRIPTION
The upstream package has a bug in Python 3.8 (https://github.com/materialsproject/api/issues/809), so we decide to drop Python 3.8 support.