### PR TITLE
exclude docs and tests from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+prune conda
+prune doc
+prune tests
+prune examples


### PR DESCRIPTION
According to https://pypi.org/project/dpgen/0.12.0/#files, these files are too large.