### PR TITLE
breaking: use `shlex.quote` to quote shell commands

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -19,6 +19,7 @@ import os
 import queue
 import random
 import re
+import shlex
 import shutil
 import sys
 import warnings
@@ -766,7 +767,7 @@ def run_train(iter_index, jdata, mdata):
             init_flag = " --finetune old/init.pb"
         command = f"{train_command} train {train_input_file}{extra_flags}"
         command = f"{{ if [ ! -f model.ckpt.index ]; then {command}{init_flag}; else {command} --restart model.ckpt; fi }}"
-        command = "/bin/sh -c '%s'" % command
+        command = "/bin/sh -c %s" % shlex.quote(command)
         commands.append(command)
         command = "%s freeze" % train_command
         commands.append(command)
@@ -1944,7 +1945,7 @@ def run_md_model_devi(iter_index, jdata, mdata):
             command = f"{{ if [ ! -f dpgen.restart.10000 ]; then {model_devi_exec} -i input.lammps -v restart 0; else {model_devi_exec} -i input.lammps -v restart 1; fi }}"
         else:
             command = f"{{ all_exist=true; for i in $(seq -w 1 {nbeads}); do [[ ! -f dpgen.restart${{i}}.10000 ]] && {{ all_exist=false; break; }}; done; $all_exist && {{ {model_devi_exec} -p {nbeads}x1 -i input.lammps -v restart 1; }} || {{ {model_devi_exec} -p {nbeads}x1 -i input.lammps -v restart 0; }} }}"
-        command = "/bin/bash -c '%s'" % command
+        command = "/bin/bash -c %s" % shlex.quote(command)
         commands = [command]
 
         forward_files = ["conf.lmp", "input.lammps"]


### PR DESCRIPTION
Single quotes (`'`) can be automatically escaped. One does not need to escape single quotes in `command` manually anymore.

To those who have escaped single quotes in `command` manually, this is a breaking change.