### PR TITLE
Fix UTs destroyed by pymatgen's update

### DIFF
--- a/dpgen/data/surf.py
+++ b/dpgen/data/surf.py
@@ -415,7 +415,10 @@ def poscar_scale(poscar_in, poscar_out, scale):
     except AttributeError:
         poscar = Poscar.from_str("".join(lines))
     with open(poscar_out, "w") as fout:
-        fout.write(poscar.get_string(direct=False))
+        try:
+            fout.write(poscar.get_string(direct=False))
+        except AttributeError:
+            fout.write(poscar.get_str(direct=False))
 
 
 def make_scale(jdata):

--- a/dpgen/data/tools/bcc.py
+++ b/dpgen/data/tools/bcc.py
@@ -17,7 +17,7 @@ def poscar_unit(latt):
     ret += f"{box[0][0]:.16f} {box[0][1]:.16f} {box[0][2]:.16f}\n"
     ret += f"{box[1][0]:.16f} {box[1][1]:.16f} {box[1][2]:.16f}\n"
     ret += f"{box[2][0]:.16f} {box[2][1]:.16f} {box[2][2]:.16f}\n"
-    ret += "Type\n"
+    ret += "X\n"
     ret += "%d\n" % numb_atoms()
     ret += "Direct\n"
     ret += f"{0.0:.16f} {0.0:.16f} {0.0:.16f}\n"

--- a/dpgen/data/tools/diamond.py
+++ b/dpgen/data/tools/diamond.py
@@ -22,7 +22,7 @@ def poscar_unit(latt):
     ret += f"{box[0][0]:.16f} {box[0][1]:.16f} {box[0][2]:.16f}\n"
     ret += f"{box[1][0]:.16f} {box[1][1]:.16f} {box[1][2]:.16f}\n"
     ret += f"{box[2][0]:.16f} {box[2][1]:.16f} {box[2][2]:.16f}\n"
-    ret += "Type\n"
+    ret += "X\n"
     ret += "%d\n" % numb_atoms()
     ret += "Direct\n"
     ret += f"{0.12500000000000:.16f} {0.12500000000000:.16f} {0.12500000000000:.16f}\n"

--- a/dpgen/data/tools/fcc.py
+++ b/dpgen/data/tools/fcc.py
@@ -17,7 +17,7 @@ def poscar_unit(latt):
     ret += f"{box[0][0]:.16f} {box[0][1]:.16f} {box[0][2]:.16f}\n"
     ret += f"{box[1][0]:.16f} {box[1][1]:.16f} {box[1][2]:.16f}\n"
     ret += f"{box[2][0]:.16f} {box[2][1]:.16f} {box[2][2]:.16f}\n"
-    ret += "Type\n"
+    ret += "X\n"
     ret += "%d\n" % numb_atoms()
     ret += "Direct\n"
     ret += f"{0.0:.16f} {0.0:.16f} {0.0:.16f}\n"

--- a/dpgen/data/tools/hcp.py
+++ b/dpgen/data/tools/hcp.py
@@ -20,7 +20,7 @@ def poscar_unit(latt):
     ret += f"{box[0][0]:.16f} {box[0][1]:.16f} {box[0][2]:.16f}\n"
     ret += f"{box[1][0]:.16f} {box[1][1]:.16f} {box[1][2]:.16f}\n"
     ret += f"{box[2][0]:.16f} {box[2][1]:.16f} {box[2][2]:.16f}\n"
-    ret += "Type\n"
+    ret += "X\n"
     ret += "%d\n" % numb_atoms()
     ret += "Direct\n"
     ret += f"{0:.16f} {0:.16f} {0:.16f}\n"

--- a/dpgen/data/tools/sc.py
+++ b/dpgen/data/tools/sc.py
@@ -17,7 +17,7 @@ def poscar_unit(latt):
     ret += f"{box[0][0]:.16f} {box[0][1]:.16f} {box[0][2]:.16f}\n"
     ret += f"{box[1][0]:.16f} {box[1][1]:.16f} {box[1][2]:.16f}\n"
     ret += f"{box[2][0]:.16f} {box[2][1]:.16f} {box[2][2]:.16f}\n"
-    ret += "Type\n"
+    ret += "X\n"
     ret += "%d\n" % numb_atoms()
     ret += "Direct\n"
     ret += f"{0.0:.16f} {0.0:.16f} {0.0:.16f}\n"

--- a/tests/generator/test_make_fp.py
+++ b/tests/generator/test_make_fp.py
@@ -414,7 +414,10 @@ def _check_kpoints(testCase, idx):
         ret = make_kspacing_kpoints(
             os.path.join(os.path.join(ii, "POSCAR")), kspacing, gamma
         )
-        kpoints_ref = Kpoints.from_string(ret)
+        try:
+            kpoints_ref = Kpoints.from_string(ret)
+        except AttributeError:
+            kpoints_ref = Kpoints.from_str(ret)
         testCase.assertEqual(repr(kpoints), repr(kpoints_ref))
 
 
@@ -496,12 +499,21 @@ def _check_incar_ele_temp(testCase, idx, ele_temp):
         tidx = int(bname.split(".")[2])
         with open("INCAR") as fp:
             incar = fp.read()
-            incar0 = Incar.from_string(incar)
+            try:
+                incar0 = Incar.from_string(incar)
+            except AttributeError:
+                incar0 = Incar.from_str(incar)
             # make_fake_md: the frames in a system shares the same ele_temp
-            incar1 = Incar.from_string(
-                vasp_incar_ele_temp_ref
-                % (ele_temp[sidx][0] * pc.Boltzmann / pc.electron_volt)
-            )
+            try:
+                incar1 = Incar.from_string(
+                    vasp_incar_ele_temp_ref
+                    % (ele_temp[sidx][0] * pc.Boltzmann / pc.electron_volt)
+                )
+            except AttributeError:
+                incar1 = Incar.from_str(
+                    vasp_incar_ele_temp_ref
+                    % (ele_temp[sidx][0] * pc.Boltzmann / pc.electron_volt)
+                )
             for ii in incar0.keys():
                 # skip checking nbands...
                 if ii == "NBANDS":


### PR DESCRIPTION
There are 2 changes in pymatgen which destroy the previous unittests:

1. https://github.com/materialsproject/pymatgen/pull/3542
Previously we set the type of DummySpecies to "Type", which is forbidden by pymatgen through this PR. Here we replace "Type" with "X".

2. https://github.com/materialsproject/pymatgen/pull/3561
The functions from_string and get_string have been replaced with from_str and get_str. We should keep up to date with these changes.