### PR TITLE
keep original model_devi.out files for pimd

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -2185,8 +2185,6 @@ def _read_model_devi_file(
             model_devi_content.shape[0] == model_devi_contents[0].shape[0]
             for model_devi_content in model_devi_contents
         ), "Not all beads generated the same number of lines in the model_devi$\{ibead\}.out file. Check your pimd task carefully."
-        for file in model_devi_files_sorted:
-            os.remove(file)
         last_step = model_devi_contents[0][-1, 0]
         for ibead in range(1, num_beads):
             model_devi_contents[ibead][:, 0] = model_devi_contents[ibead][


### PR DESCRIPTION
The previous implementation of deleting model_devi.out files after they are concatenated to a single file is not a good practice. It does not allow one to keep track of the behaviors of each bead. This PR keeps the original model_devi.out files for pimd.