### PR TITLE
docs: fix author name

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Jinzhe Zeng <jinzhe.zeng@rutgers.edu>


### PR DESCRIPTION
Fix my name at https://docs.deepmodeling.com/projects/dpgen/en/latest/credits.html. An incorrect name, "Jinzh Zeng", was used in a commit.
See https://git-scm.com/docs/gitmailmap for the principle.

I didn't fix other people's names, but they can do the same thing as this PR.