### PR TITLE
fix: fix `SyntaxWarning: invalid escape sequence`

### DIFF
--- a/dpgen/auto_test/Gamma.py
+++ b/dpgen/auto_test/Gamma.py
@@ -386,7 +386,7 @@ class Gamma(Property):
         with open(inLammps) as fin1:
             contents = fin1.readlines()
             for ii in range(len(contents)):
-                upper = re.search("variable        N equal count\(all\)", contents[ii])
+                upper = re.search(r"variable        N equal count\(all\)", contents[ii])
                 lower = re.search("min_style       cg", contents[ii])
                 if lower:
                     lower_id = ii


### PR DESCRIPTION
```
/home/runner/work/dpgen/dpgen/dpgen/auto_test/Gamma.py:389: SyntaxWarning: invalid escape sequence '\('
  upper = re.search("variable        N equal count\(all\)", contents[ii])
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of the Gamma module by correcting a regular expression pattern. This change ensures more accurate data parsing and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->