### PR TITLE
fix: fix typo in run_train

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -728,7 +728,7 @@ def get_nframes(system):
 def run_train(iter_index, jdata, mdata):
     mlp_engine = jdata.get("mlp_engine", "dp")
     if mlp_engine == "dp":
-        return make_train_dp(iter_index, jdata, mdata)
+        return run_train_dp(iter_index, jdata, mdata)
     else:
         raise ValueError(f"Unsupported engine: {mlp_engine}")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed internal function `make_train_dp` to `run_train_dp` for better clarity and consistency within the codebase. 

(Note: This change does not impact end-user functionalities directly.)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->