### PR TITLE
fix: fix `dtype` of `keywords_high_multiplicity`

### DIFF
--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -709,7 +709,7 @@ def fp_style_gaussian_args() -> list[Argument]:
         Argument("basis_set", str, optional=True, doc=doc_basis_set),
         Argument(
             "keywords_high_multiplicity",
-            str,
+            [str, list[str]],
             optional=True,
             doc=doc_keywords_high_multiplicity,
         ),


### PR DESCRIPTION
which should have the same `dtype` as `keywords`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced flexibility in configuration by allowing `keywords_high_multiplicity` to accept both strings and lists of strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->