### PR TITLE
fix: skip setting seed when descriptor/fitting_net doesn't exist

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -583,7 +583,9 @@ def make_train_dp(iter_index, jdata, mdata):
             mdata["deepmd_version"]
         ) < Version("3"):
             # 1.x
-            if jinput["model"]["descriptor"]["type"] == "hybrid":
+            if "descriptor" not in jinput["model"]:
+                pass
+            elif jinput["model"]["descriptor"]["type"] == "hybrid":
                 for desc in jinput["model"]["descriptor"]["list"]:
                     desc["seed"] = random.randrange(sys.maxsize) % (2**32)
             elif jinput["model"]["descriptor"]["type"] == "loc_frame":
@@ -592,9 +594,10 @@ def make_train_dp(iter_index, jdata, mdata):
                 jinput["model"]["descriptor"]["seed"] = random.randrange(
                     sys.maxsize
                 ) % (2**32)
-            jinput["model"]["fitting_net"]["seed"] = random.randrange(sys.maxsize) % (
-                2**32
-            )
+            if "fitting_net" in jinput["model"]:
+                jinput["model"]["fitting_net"]["seed"] = random.randrange(
+                    sys.maxsize
+                ) % (2**32)
             if "type_embedding" in jinput["model"]:
                 jinput["model"]["type_embedding"]["seed"] = random.randrange(
                     sys.maxsize


### PR DESCRIPTION
Support some corner cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of model descriptor and fitting network keys to ensure robust seed setting in training functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->