### PR TITLE
docs(deps): pin `sphinx_rtd_theme` to `>=0.6`

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
 # https://github.com/sphinx-doc/sphinx/issues/11662
 sphinx>=4.0.2,!=7.2.5
 recommonmark
-sphinx_rtd_theme
+sphinx_rtd_theme>=0.6
 sphinx_markdown_tables
 sphinx-argparse<0.5.0
 myst-parser


### PR DESCRIPTION
See https://github.com/readthedocs/sphinx_rtd_theme/issues/1571#issuecomment-2271988123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `sphinx_rtd_theme` package to ensure compatibility, enhancing project stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->