### PR TITLE
Change default deepmd_version and make the screen output complete

### DIFF
--- a/dpgen/__init__.py
+++ b/dpgen/__init__.py
@@ -5,6 +5,7 @@ ROOT_PATH = __path__[0]
 NAME = "dpgen"
 SHORT_CMD = "dpgen"
 dlog = logging.getLogger(__name__)
+dlog.propagate = False
 dlog.setLevel(logging.INFO)
 dlogf = logging.FileHandler(os.getcwd() + os.sep + SHORT_CMD + ".log", delay=True)
 dlogf_formatter = logging.Formatter("%(asctime)s - %(levelname)s : %(message)s")

--- a/dpgen/__init__.py
+++ b/dpgen/__init__.py
@@ -11,7 +11,7 @@ dlogf_formatter = logging.Formatter("%(asctime)s - %(levelname)s : %(message)s")
 # dlogf_formatter=logging.Formatter('%(asctime)s - %(name)s - [%(filename)s:%(funcName)s - %(lineno)d ] - %(levelname)s \n %(message)s')
 dlogf.setFormatter(dlogf_formatter)
 dlog.addHandler(dlogf)
-logging.addHandler(logging.StreamHandler())
+logging.basicConfig(level=logging.WARNING)
 
 __author__ = "Han Wang"
 __copyright__ = "Copyright 2019"

--- a/dpgen/__init__.py
+++ b/dpgen/__init__.py
@@ -5,13 +5,13 @@ ROOT_PATH = __path__[0]
 NAME = "dpgen"
 SHORT_CMD = "dpgen"
 dlog = logging.getLogger(__name__)
-dlog.propagate = False
 dlog.setLevel(logging.INFO)
 dlogf = logging.FileHandler(os.getcwd() + os.sep + SHORT_CMD + ".log", delay=True)
 dlogf_formatter = logging.Formatter("%(asctime)s - %(levelname)s : %(message)s")
 # dlogf_formatter=logging.Formatter('%(asctime)s - %(name)s - [%(filename)s:%(funcName)s - %(lineno)d ] - %(levelname)s \n %(message)s')
 dlogf.setFormatter(dlogf_formatter)
 dlog.addHandler(dlogf)
+logging.addHandler(logging.StreamHandler())
 
 __author__ = "Han Wang"
 __copyright__ = "Copyright 2019"

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -4693,7 +4693,7 @@ def post_fp(iter_index, jdata):
 
 
 def set_version(mdata):
-    deepmd_version = "1"
+    deepmd_version = "2"
     mdata["deepmd_version"] = deepmd_version
     return mdata
 

--- a/tests/generator/machine-local-v1.json
+++ b/tests/generator/machine-local-v1.json
@@ -1,4 +1,5 @@
 {
+    "deepmd_version": "1",
     "train_machine": {
         "machine_type": "shell",
         "lazy_local": true


### PR DESCRIPTION
1. make default deepmd_version setting be consistent with the doc
2. add StreamHandlers to root logger to make the screen output complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated versioning information for improved clarity.
	- Added a versioning element in the configuration for tracking and compatibility.
- **Bug Fixes**
	- Enhanced logging configuration to improve message handling and visibility during runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->