### PR TITLE
support fparam in lmp template

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -1005,7 +1005,9 @@ def find_only_one_key(lmp_lines, key):
     return found[0]
 
 
-def revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version="1", use_ele_temp=0):
+def revise_lmp_input_model(
+    lmp_lines, task_model_list, trj_freq, deepmd_version="1", use_ele_temp=0
+):
     idx = find_only_one_key(lmp_lines, ["pair_style", "deepmd"])
     graph_list = " ".join(task_model_list)
     if Version(deepmd_version) < Version("1"):
@@ -1015,21 +1017,21 @@ def revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version=
         )
     else:
         if use_ele_temp == 0:
-                lmp_lines[idx] = (
-                    "pair_style      deepmd %s out_freq %d out_file model_devi.out\n"
-                    % (
-                        graph_list,
-                        trj_freq,
-                    )
+            lmp_lines[idx] = (
+                "pair_style      deepmd %s out_freq %d out_file model_devi.out\n"
+                % (
+                    graph_list,
+                    trj_freq,
                 )
+            )
         elif use_ele_temp == 1:
-                lmp_lines[idx] = (
-                    "pair_style      deepmd %s out_freq %d out_file model_devi.out fparam ${ELE_TEMP}\n"
-                    % (
-                        graph_list,
-                        trj_freq,
-                    )
-                )                
+            lmp_lines[idx] = (
+                "pair_style      deepmd %s out_freq %d out_file model_devi.out fparam ${ELE_TEMP}\n"
+                % (
+                    graph_list,
+                    trj_freq,
+                )
+            )
     return lmp_lines
 
 
@@ -1405,7 +1407,7 @@ def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
                                 task_model_list,
                                 trj_freq,
                                 deepmd_version=deepmd_version,
-                                use_ele_temp=use_ele_temp
+                                use_ele_temp=use_ele_temp,
                             )
                     else:
                         if len(lmp_lines[template_pair_deepmd_idx].split()) != (
@@ -1426,7 +1428,7 @@ def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
                                 task_model_list,
                                 trj_freq,
                                 deepmd_version=deepmd_version,
-                                use_ele_temp=use_ele_temp
+                                use_ele_temp=use_ele_temp,
                             )
                 # use revise_lmp_input_model to raise error message if "part_style" or "deepmd" not found
                 else:
@@ -1435,7 +1437,7 @@ def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
                         task_model_list,
                         trj_freq,
                         deepmd_version=deepmd_version,
-                        use_ele_temp=use_ele_temp
+                        use_ele_temp=use_ele_temp,
                     )
 
                 lmp_lines = revise_lmp_input_dump(

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -1005,7 +1005,7 @@ def find_only_one_key(lmp_lines, key):
     return found[0]
 
 
-def revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version="1"):
+def revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version="1", use_ele_temp=0):
     idx = find_only_one_key(lmp_lines, ["pair_style", "deepmd"])
     graph_list = " ".join(task_model_list)
     if Version(deepmd_version) < Version("1"):
@@ -1014,13 +1014,22 @@ def revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version=
             trj_freq,
         )
     else:
-        lmp_lines[idx] = (
-            "pair_style      deepmd %s out_freq %d out_file model_devi.out\n"
-            % (
-                graph_list,
-                trj_freq,
-            )
-        )
+        if use_ele_temp == 0:
+                lmp_lines[idx] = (
+                    "pair_style      deepmd %s out_freq %d out_file model_devi.out\n"
+                    % (
+                        graph_list,
+                        trj_freq,
+                    )
+                )
+        elif use_ele_temp == 1:
+                lmp_lines[idx] = (
+                    "pair_style      deepmd %s out_freq %d out_file model_devi.out fparam ${ELE_TEMP}\n"
+                    % (
+                        graph_list,
+                        trj_freq,
+                    )
+                )                
     return lmp_lines
 
 
@@ -1289,6 +1298,8 @@ def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
     sys_idx = expand_idx(cur_job["sys_idx"])
     if len(sys_idx) != len(list(set(sys_idx))):
         raise RuntimeError("system index should be uniq")
+
+    use_ele_temp = jdata.get("use_ele_temp", 0)
     mass_map = jdata["mass_map"]
     use_plm = jdata.get("model_devi_plumed", False)
     use_plm_path = jdata.get("model_devi_plumed_path", False)
@@ -1394,6 +1405,7 @@ def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
                                 task_model_list,
                                 trj_freq,
                                 deepmd_version=deepmd_version,
+                                use_ele_temp=use_ele_temp
                             )
                     else:
                         if len(lmp_lines[template_pair_deepmd_idx].split()) != (
@@ -1414,6 +1426,7 @@ def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
                                 task_model_list,
                                 trj_freq,
                                 deepmd_version=deepmd_version,
+                                use_ele_temp=use_ele_temp
                             )
                 # use revise_lmp_input_model to raise error message if "part_style" or "deepmd" not found
                 else:
@@ -1422,6 +1435,7 @@ def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
                         task_model_list,
                         trj_freq,
                         deepmd_version=deepmd_version,
+                        use_ele_temp=use_ele_temp
                     )
 
                 lmp_lines = revise_lmp_input_dump(


### PR DESCRIPTION

in previous version, if we use `template` in model deviation process, the generated LAMMPS input file would neglect fparam-dependence in DP model, as
```
pair_style      deepmd ../graph.000.pb ../graph.001.pb ../graph.002.pb ../graph.003.pb out_freq 10 out_file model_devi.out 
pair_coeff      * *
```



here we fixed this problem, as 
```
pair_style      deepmd ../graph.000.pb ../graph.001.pb ../graph.002.pb ../graph.003.pb out_freq 10 out_file model_devi.out fparam ${ELE_TEMP}
pair_coeff      * *

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the LAMMPS input model to support configurations based on electron temperature settings.
	- Added flexibility in handling different input scenarios with the introduction of a new parameter.

- **Bug Fixes**
	- Improved compatibility checks for the specified DeepMD version in the input model construction.

- **Documentation**
	- Updated comments for clarity regarding the new functionality and parameter usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->