### PR TITLE
Revert "fix(CI): remove `CI` env var to fix the CI"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,7 @@ jobs:
     - name: Install dependencies
       run: uv pip install --system -e .[test]
     - name: Test
-      run: |
-        # https://github.com/materialsproject/pymatgen/issues/4243#issuecomment-2573310051
-        unset CI
-        coverage run --source=./dpgen -m unittest -v && coverage report
+      run: coverage run --source=./dpgen -m unittest -v && coverage report
     - uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Reverts deepmodeling/dpgen#1704

See https://github.com/materialsproject/pymatgen/issues/4243#issuecomment-2581664182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration for testing.
	- Simplified test execution process in the CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->