### PR TITLE
Update shuffle_poscar feature in run.py

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -1305,7 +1305,7 @@ def make_model_devi(iter_index, jdata, mdata):
                     type_map=jdata["type_map"],
                 )
                 if shuffle_poscar:
-                    system.data["coords"] = rng.permuted(system.data["coords"], axis=1)
+                    rng.shuffle(system.data["coords"], axis=1) 
                 if jdata.get("model_devi_nopbc", False):
                     system.remove_pbc()
                 system.to_lammps_lmp(os.path.join(conf_path, lmp_name))

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -1305,7 +1305,7 @@ def make_model_devi(iter_index, jdata, mdata):
                     type_map=jdata["type_map"],
                 )
                 if shuffle_poscar:
-                    rng.shuffle(system.data["coords"], axis=1) 
+                    rng.shuffle(system.data["coords"], axis=1)
                 if jdata.get("model_devi_nopbc", False):
                     system.remove_pbc()
                 system.to_lammps_lmp(os.path.join(conf_path, lmp_name))


### PR DESCRIPTION
numpy.random.Generator.shuffle() performs the intended operation of shuffling the order of atoms. numpy.random.Generator.permuted() permutes the elements along the given axis, which mixes the coordinates of all atoms
shuffle
![shuffle](https://github.com/user-attachments/assets/ef814c7a-72b3-4d13-b6cc-1612a1fe6fc6)
permuted
![permuted](https://github.com/user-attachments/assets/ea6e9be0-74e7-4e43-a008-0d65ec0839ee)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the process that randomizes system coordinates when a specific option is enabled, enhancing internal data handling and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->