### PR TITLE
fix(init_bulk): include the last perturbation in collected vasp data

### DIFF
--- a/dpgen/data/gen.py
+++ b/dpgen/data/gen.py
@@ -1071,7 +1071,7 @@ def coll_vasp_md(jdata):
         # convert outcars
         valid_outcars = []
         for jj in scale:
-            for kk in range(pert_numb):
+            for kk in range(pert_numb + 1):
                 path_work = os.path.join(f"scale-{jj:.3f}", "%06d" % kk)  # noqa: UP031
                 outcar = os.path.join(path_work, "OUTCAR")
                 # dlog.info("OUTCAR",outcar)


### PR DESCRIPTION
Fix #1745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the processing of molecular dynamics data directories to ensure all relevant perturbation indices are included during data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->