### PR TITLE
fix: remove duplicated reading model deviation files

### DIFF
--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -2477,7 +2477,6 @@ def _select_by_model_devi_adaptive_trust_low(
     for tt in modd_system_task:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            model_devi = np.loadtxt(os.path.join(tt, "model_devi.out"))
             model_devi = _read_model_devi_file(
                 tt, model_devi_f_avg_relative, model_devi_merge_traj
             )


### PR DESCRIPTION
The line I removed seems to be unused. xref: 1c18b1cecf241e1d74702e5c116a2f7a82b89bb4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved consistency in reading model deviation data by using a unified helper function for file processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->