### PR TITLE
fix: align mdata arginfo with runtime machine sections

### DIFF
--- a/dpgen/arginfo.py
+++ b/dpgen/arginfo.py
@@ -1,5 +1,15 @@
 from dargs import Argument
 
+
+def _is_mdata_task_config(value):
+    """Return whether a machine task section matches runtime accepted shapes."""
+    if isinstance(value, dict):
+        return True
+    if isinstance(value, list):
+        return all(isinstance(item, dict) for item in value)
+    return False
+
+
 from dpgen.dispatcher.Dispatcher import mdata_arginfo
 
 
@@ -34,9 +44,14 @@ def general_mdata_arginfo(name: str, tasks: tuple[str]) -> Argument:
         sub_fields.append(
             Argument(
                 task,
-                dict,
+                (dict, list),
                 optional=False,
                 sub_fields=mdata_arginfo(),
+                extra_check=_is_mdata_task_config,
+                extra_check_errmsg=(
+                    "expected a dict or a list of dicts, matching "
+                    "convert_mdata() runtime semantics"
+                ),
                 doc=doc_mdata % task,
             )
         )

--- a/dpgen/arginfo.py
+++ b/dpgen/arginfo.py
@@ -2,11 +2,22 @@ from dargs import Argument
 
 
 def _is_mdata_task_config(value):
-    """Return whether a machine task section matches runtime accepted shapes."""
+    """Return whether a machine task section matches runtime accepted shapes.
+
+    Parameters
+    ----------
+    value : object
+        Candidate value for one machine task section, such as ``train``.
+
+    Returns
+    -------
+    bool
+        Whether the value is a dict or a non-empty list of dicts.
+    """
     if isinstance(value, dict):
         return True
     if isinstance(value, list):
-        return all(isinstance(item, dict) for item in value)
+        return len(value) > 0 and all(isinstance(item, dict) for item in value)
     return False
 
 

--- a/tests/test_mdata_arginfo.py
+++ b/tests/test_mdata_arginfo.py
@@ -56,6 +56,12 @@ class TestRunMdataArginfo(unittest.TestCase):
         with self.assertRaises(ArgumentValueError):
             normalize(run_mdata_arginfo(), data, strict_check=False)
 
+    def test_rejects_empty_list_section(self):
+        data = _mdata(lambda item: item)
+        data["train"] = []
+        with self.assertRaises(ArgumentValueError):
+            normalize(run_mdata_arginfo(), data, strict_check=False)
+
     def test_rejects_scalar_section(self):
         data = _mdata(lambda item: item)
         data["train"] = "not-a-task-section"

--- a/tests/test_mdata_arginfo.py
+++ b/tests/test_mdata_arginfo.py
@@ -1,0 +1,63 @@
+import copy
+import unittest
+
+from dargs.dargs import ArgumentTypeError, ArgumentValueError
+
+from dpgen.generator.arginfo import run_mdata_arginfo
+from dpgen.remote.decide_machine import convert_mdata
+from dpgen.util import normalize
+
+
+def _task(command):
+    return {
+        "command": command,
+        "machine": {
+            "batch_type": "Shell",
+            "context_type": "local",
+            "local_root": "./",
+            "remote_root": "/tmp/dpgen",
+        },
+        "resources": {
+            "batch_type": "Shell",
+            "number_node": 1,
+            "cpu_per_node": 4,
+            "gpu_per_node": 0,
+            "group_size": 1,
+        },
+    }
+
+
+def _mdata(section_wrapper):
+    return {
+        "api_version": "1.0",
+        "train": section_wrapper(_task("dp")),
+        "model_devi": section_wrapper(_task("lmp")),
+        "fp": section_wrapper(_task("vasp")),
+    }
+
+
+class TestRunMdataArginfo(unittest.TestCase):
+    def test_accepts_dict_sections(self):
+        data = _mdata(lambda item: item)
+        normalize(run_mdata_arginfo(), data, strict_check=False)
+
+    def test_accepts_list_sections_used_by_runtime(self):
+        data = _mdata(lambda item: [item])
+        normalize(run_mdata_arginfo(), data, strict_check=False)
+
+        converted = convert_mdata(copy.deepcopy(data))
+        self.assertEqual(converted["train_command"], "dp")
+        self.assertEqual(converted["model_devi_command"], "lmp")
+        self.assertEqual(converted["fp_command"], "vasp")
+
+    def test_rejects_list_with_non_dict_item(self):
+        data = _mdata(lambda item: item)
+        data["train"] = ["not-a-task-dict"]
+        with self.assertRaises(ArgumentValueError):
+            normalize(run_mdata_arginfo(), data, strict_check=False)
+
+    def test_rejects_scalar_section(self):
+        data = _mdata(lambda item: item)
+        data["train"] = "not-a-task-section"
+        with self.assertRaises(ArgumentTypeError):
+            normalize(run_mdata_arginfo(), data, strict_check=False)


### PR DESCRIPTION
## Summary

- Align `general_mdata_arginfo()` with `convert_mdata()` runtime semantics for machine task sections.
- Allow `train`, `model_devi`, and `fp` to be either a dict or a list of dicts.
- Add regression tests covering dict-form, list-form, scalar rejection, and list-with-non-dict rejection.

## Related

Related to deepmodeling/dpgen#1888.

## Why

`dpgen run` accepts list-form machine sections through `convert_mdata()`:

```python
elif isinstance(mdata[task_type], (list, tuple)):
    task_data = mdata[task_type][0]
```

But `run_mdata_arginfo()` previously exposed these sections as dict-only, causing external validators/tools to falsely reject machine files that runtime accepts.

## Validation

- `python -m pytest tests/test_mdata_arginfo.py tests/test_check_examples.py tests/tools/test_convert_mdata.py -q`
- `python -m ruff check dpgen/arginfo.py tests/test_mdata_arginfo.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime validation for metadata task configurations, accepting either task sections as `dict` objects or as non-empty lists of `dict` objects.
  * Added clearer error messaging when metadata task inputs don’t match the expected runtime shape.

* **Tests**
  * Added new unit tests covering acceptance of valid task section formats.
  * Added coverage for rejection cases including lists with non-dict items, empty lists, and scalar inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->