### PR TITLE
Fix AttributeError in ABACUS Gamma post-processing (self.addfix -> self.add_fix)

### DIFF
--- a/dpgen/auto_test/Gamma.py
+++ b/dpgen/auto_test/Gamma.py
@@ -369,7 +369,7 @@ class Gamma(Property):
 
     def __stru_fix(self, stru) -> None:
         fix_dict = {"true": True, "false": False}
-        fix_xyz = [fix_dict[i] for i in self.addfix]
+        fix_xyz = [fix_dict[i] for i in self.add_fix]
         abacus.stru_fix_atom(stru, fix_atom=fix_xyz)
 
     def __inLammpes_fix(self, inLammps) -> None:


### PR DESCRIPTION
Fixes #1900.

`Gamma.__stru_fix` referenced `self.addfix`, but the attribute is `self.add_fix` (set in `__init__`). This raised an AttributeError whenever `add_fix` was enabled during ABACUS Gamma post-processing. Corrected the spelling to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in Abaqus post-processing where structure-fix handling could fail due to an incorrect setting reference.
  * Improved stability for runs that use fix-point adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->