### PR TITLE
Fix CITATION.cff top-level metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,3 +1,21 @@
+cff-version: 1.2.0
+message: "If you use DP-GEN, please cite it using the metadata from this file."
+type: software
+title: "DP-GEN: A concurrent learning platform for the generation of reliable deep learning based potential energy models"
+abstract: "The deep potential generator to generate a deep-learning based model of interatomic potential energy and force field."
+authors:
+- name: "DeepModeling"
+- family-names: "Wang"
+  given-names: "Han"
+  email: "wang_han@iapcm.ac.cn"
+repository-code: "https://github.com/deepmodeling/dpgen"
+url: "https://docs.deepmodeling.com/projects/dpgen"
+license: LGPL-3.0-or-later
+keywords:
+- deep-potential-generator
+- active-learning
+- deepmd-kit
+
 preferred-citation:
   type: article
   authors:


### PR DESCRIPTION
Related to #1916.

This keeps the existing article citation as `preferred-citation`, and adds the required top-level CFF metadata for the software itself: `cff-version`, message, type, title, authors, repository, URL, license, and keywords.

I intentionally did not change the existing preferred article citation.

Local checks:

- parsed `CITATION.cff` as YAML and checked that `cff-version` and `preferred-citation` are present;
- `git diff --check`.

I could not run `cffconvert --validate` locally because `cffconvert` is not installed in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added citation information for DP-GEN, including how to reference the software, project details, author information, repository and documentation links, license, and keywords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->