### PR TITLE
feat: support DPA4 and DPA4C model formats

### DIFF
--- a/doc/run/param.rst
+++ b/doc/run/param.rst
@@ -19,15 +19,14 @@ uses the regular PyTorch backend for both training and export:
 
    {
      "train_backend": "pytorch",
-     "model_devi_backend": "pytorch",
-     "model_format": "pt2",
-     "default_training_param": {
-        "model": {
-           "type": "dpa4",
-           "use_compile": true,
-           "enable_tf32": true
-        }
-     }
+       "model_format": "pt2",
+       "default_training_param": {
+          "model": {
+             "type": "dpa4",
+             "use_compile": true,
+             "enable_tf32": true
+          }
+       }
    }
 
 DPA4C uses the PyTorch-exportable backend for both training and graph export:
@@ -36,27 +35,23 @@ DPA4C uses the PyTorch-exportable backend for both training and graph export:
 
    {
      "train_backend": "pytorch-exportable",
-     "model_devi_backend": "pytorch-exportable",
      "model_format": "pt2",
-     "dp_compress": true,
-     "default_training_param": {
-        "model": {
-           "descriptor": {"type": "dpa4c"}
-        },
-        "training": {
-           "enable_compile": true,
-           "enable_tf32": true
-        }
-     }
+       "dp_compress": true,
+       "default_training_param": {
+          "model": {
+             "descriptor": {"type": "dpa4c"}
+          },
+          "training": {
+             "enable_compile": true,
+             "enable_tf32": true
+          }
+       }
    }
 
-The default ``train_backend`` remains ``tensorflow``.
-``model_devi_backend`` defaults to ``train_backend`` but independently selects
-the backend flag used by ``freeze`` and ``compress``. ``pt-expt`` is accepted as
-an alias of ``pytorch-exportable``. PyTorch-exportable model deviation with
+The default ``train_backend`` remains ``tensorflow``. ``pt-expt`` is accepted
+as an alias of ``pytorch-exportable``. PyTorch-exportable model deviation with
 LAMMPS defaults to ``pt2``. Training checkpoints keep the ``.pt`` suffix
-independently of the frozen model format. Regular PyTorch ``pt2`` export is
-accepted only for DPA4/SeZM training templates.
+independently of the frozen model format.
 
 The acceleration controls belong to different sections of the DeePMD training
 template: DPA4 uses ``model.use_compile`` and ``model.enable_tf32``; DPA4C uses

--- a/doc/run/param.rst
+++ b/doc/run/param.rst
@@ -19,6 +19,7 @@ regular PyTorch DPA4 model can be exported as an AOTInductor archive with:
 
    {
      "train_backend": "pytorch",
+     "model_devi_backend": "pytorch-exportable",
      "model_format": "pt2"
    }
 
@@ -36,3 +37,9 @@ export explicitly:
 ``pt-expt`` is accepted as an alias of ``pytorch-exportable``. The ``pte``
 format remains available for dense PyTorch-exportable models. Training
 checkpoints keep the ``.pt`` suffix independently of the frozen model format.
+The ``model_devi_backend`` setting makes ``dpgen`` train with ``dp --pt`` but
+freeze (and optionally compress) with ``dp --pt-expt``. The resulting ``.pt2``
+models are automatically linked into the model-deviation stage and listed in
+the generated LAMMPS input. For Kokkos execution, configure the model-deviation
+command to invoke a Kokkos-enabled LAMMPS build, for example
+``lmp -k on g 1 -sf kk``.

--- a/doc/run/param.rst
+++ b/doc/run/param.rst
@@ -19,14 +19,14 @@ uses the regular PyTorch backend for both training and export:
 
    {
      "train_backend": "pytorch",
-       "model_format": "pt2",
-       "default_training_param": {
-          "model": {
-             "type": "dpa4",
-             "use_compile": true,
-             "enable_tf32": true
-          }
+     "model_format": "pt2",
+     "default_training_param": {
+       "model": {
+         "type": "dpa4",
+         "use_compile": true,
+         "enable_tf32": true
        }
+     }
    }
 
 DPA4C uses the PyTorch-exportable backend for both training and graph export:
@@ -36,22 +36,26 @@ DPA4C uses the PyTorch-exportable backend for both training and graph export:
    {
      "train_backend": "pytorch-exportable",
      "model_format": "pt2",
-       "dp_compress": true,
-       "default_training_param": {
-          "model": {
-             "descriptor": {"type": "dpa4c"}
-          },
-          "training": {
-             "enable_compile": true,
-             "enable_tf32": true
-          }
+     "dp_compress": true,
+     "default_training_param": {
+       "model": {
+         "descriptor": {"type": "dpa4c"}
+       },
+       "training": {
+         "enable_compile": true,
+         "enable_tf32": true
        }
+     }
    }
 
 The default ``train_backend`` remains ``tensorflow``. ``pt-expt`` is accepted
 as an alias of ``pytorch-exportable``. PyTorch-exportable model deviation with
 LAMMPS defaults to ``pt2``. Training checkpoints keep the ``.pt`` suffix
 independently of the frozen model format.
+
+Freeze and export use the same backend as training. Regular PyTorch and
+PyTorch-exportable checkpoints are backend-specific and cannot be converted by
+switching the ``dp`` backend flag after training.
 
 The acceleration controls belong to different sections of the DeePMD training
 template: DPA4 uses ``model.use_compile`` and ``model.enable_tf32``; DPA4C uses

--- a/doc/run/param.rst
+++ b/doc/run/param.rst
@@ -40,6 +40,4 @@ checkpoints keep the ``.pt`` suffix independently of the frozen model format.
 The ``model_devi_backend`` setting makes ``dpgen`` train with ``dp --pt`` but
 freeze (and optionally compress) with ``dp --pt-expt``. The resulting ``.pt2``
 models are automatically linked into the model-deviation stage and listed in
-the generated LAMMPS input. For Kokkos execution, configure the model-deviation
-command to invoke a Kokkos-enabled LAMMPS build, for example
-``lmp -k on g 1 -sf kk``.
+the generated LAMMPS input.

--- a/doc/run/param.rst
+++ b/doc/run/param.rst
@@ -19,7 +19,14 @@ uses the regular PyTorch backend for both training and export:
 
    {
      "train_backend": "pytorch",
-     "model_format": "pt2"
+       "model_format": "pt2",
+       "default_training_param": {
+          "model": {
+             "type": "dpa4",
+             "use_compile": true,
+             "enable_tf32": true
+          }
+       }
    }
 
 DPA4C uses the PyTorch-exportable backend for both training and graph export:
@@ -29,13 +36,28 @@ DPA4C uses the PyTorch-exportable backend for both training and graph export:
    {
      "train_backend": "pytorch-exportable",
      "model_format": "pt2",
-     "dp_compress": true
+       "dp_compress": true,
+       "default_training_param": {
+          "model": {
+             "descriptor": {"type": "dpa4c"}
+          },
+          "training": {
+             "enable_compile": true,
+             "enable_tf32": true
+          }
+       }
    }
 
 The default ``train_backend`` remains ``tensorflow``. ``pt-expt`` is accepted
 as an alias of ``pytorch-exportable``. PyTorch-exportable model deviation with
 LAMMPS defaults to ``pt2``. Training checkpoints keep the ``.pt`` suffix
 independently of the frozen model format.
+
+The acceleration controls belong to different sections of the DeePMD training
+template: DPA4 uses ``model.use_compile`` and ``model.enable_tf32``; DPA4C uses
+``training.enable_compile`` and ``training.enable_tf32``. DP-GEN validates the
+backend and these locations but does not inject either policy. A template cannot
+mix DPA4 and DPA4C branches because they require different training backends.
 
 AOTInductor ``.pt2`` archives are specific to the target CPU or GPU, GPU
 compute capability, and libtorch version. DP-GEN therefore finishes the

--- a/doc/run/param.rst
+++ b/doc/run/param.rst
@@ -19,14 +19,15 @@ uses the regular PyTorch backend for both training and export:
 
    {
      "train_backend": "pytorch",
-       "model_format": "pt2",
-       "default_training_param": {
-          "model": {
-             "type": "dpa4",
-             "use_compile": true,
-             "enable_tf32": true
-          }
-       }
+     "model_devi_backend": "pytorch",
+     "model_format": "pt2",
+     "default_training_param": {
+        "model": {
+           "type": "dpa4",
+           "use_compile": true,
+           "enable_tf32": true
+        }
+     }
    }
 
 DPA4C uses the PyTorch-exportable backend for both training and graph export:
@@ -35,23 +36,27 @@ DPA4C uses the PyTorch-exportable backend for both training and graph export:
 
    {
      "train_backend": "pytorch-exportable",
+     "model_devi_backend": "pytorch-exportable",
      "model_format": "pt2",
-       "dp_compress": true,
-       "default_training_param": {
-          "model": {
-             "descriptor": {"type": "dpa4c"}
-          },
-          "training": {
-             "enable_compile": true,
-             "enable_tf32": true
-          }
-       }
+     "dp_compress": true,
+     "default_training_param": {
+        "model": {
+           "descriptor": {"type": "dpa4c"}
+        },
+        "training": {
+           "enable_compile": true,
+           "enable_tf32": true
+        }
+     }
    }
 
-The default ``train_backend`` remains ``tensorflow``. ``pt-expt`` is accepted
-as an alias of ``pytorch-exportable``. PyTorch-exportable model deviation with
+The default ``train_backend`` remains ``tensorflow``.
+``model_devi_backend`` defaults to ``train_backend`` but independently selects
+the backend flag used by ``freeze`` and ``compress``. ``pt-expt`` is accepted as
+an alias of ``pytorch-exportable``. PyTorch-exportable model deviation with
 LAMMPS defaults to ``pt2``. Training checkpoints keep the ``.pt`` suffix
-independently of the frozen model format.
+independently of the frozen model format. Regular PyTorch ``pt2`` export is
+accepted only for DPA4/SeZM training templates.
 
 The acceleration controls belong to different sections of the DeePMD training
 template: DPA4 uses ``model.use_compile`` and ``model.enable_tf32``; DPA4C uses

--- a/doc/run/param.rst
+++ b/doc/run/param.rst
@@ -8,3 +8,31 @@ dpgen run param parameters
 .. dargs::
    :module: dpgen.generator.arginfo
    :func: run_jdata_arginfo
+
+DPA4 and DPA4C
+---------------
+
+DPA4 and the PyTorch-exportable backend require DeePMD-kit 3.2 or later. A
+regular PyTorch DPA4 model can be exported as an AOTInductor archive with:
+
+.. code-block:: json
+
+   {
+     "train_backend": "pytorch",
+     "model_format": "pt2"
+   }
+
+For DPA4C, and for DPA4 using the PyTorch-exportable backend, select the graph
+export explicitly:
+
+.. code-block:: json
+
+   {
+     "train_backend": "pytorch-exportable",
+     "model_format": "pt2",
+     "dp_compress": true
+   }
+
+``pt-expt`` is accepted as an alias of ``pytorch-exportable``. The ``pte``
+format remains available for dense PyTorch-exportable models. Training
+checkpoints keep the ``.pt`` suffix independently of the frozen model format.

--- a/doc/run/param.rst
+++ b/doc/run/param.rst
@@ -12,19 +12,17 @@ dpgen run param parameters
 DPA4 and DPA4C
 ---------------
 
-DPA4 and the PyTorch-exportable backend require DeePMD-kit 3.2 or later. A
-regular PyTorch DPA4 model can be exported as an AOTInductor archive with:
+DPA4 and the PyTorch-exportable backend require DeePMD-kit 3.2 or later. DPA4
+uses the regular PyTorch backend for both training and export:
 
 .. code-block:: json
 
    {
      "train_backend": "pytorch",
-     "model_devi_backend": "pytorch-exportable",
      "model_format": "pt2"
    }
 
-For DPA4C, and for DPA4 using the PyTorch-exportable backend, select the graph
-export explicitly:
+DPA4C uses the PyTorch-exportable backend for both training and graph export:
 
 .. code-block:: json
 
@@ -34,10 +32,18 @@ export explicitly:
      "dp_compress": true
    }
 
-``pt-expt`` is accepted as an alias of ``pytorch-exportable``. The ``pte``
-format remains available for dense PyTorch-exportable models. Training
-checkpoints keep the ``.pt`` suffix independently of the frozen model format.
-The ``model_devi_backend`` setting makes ``dpgen`` train with ``dp --pt`` but
-freeze (and optionally compress) with ``dp --pt-expt``. The resulting ``.pt2``
-models are automatically linked into the model-deviation stage and listed in
-the generated LAMMPS input.
+The default ``train_backend`` remains ``tensorflow``. ``pt-expt`` is accepted
+as an alias of ``pytorch-exportable``. PyTorch-exportable model deviation with
+LAMMPS defaults to ``pt2``. Training checkpoints keep the ``.pt`` suffix
+independently of the frozen model format.
+
+AOTInductor ``.pt2`` archives are specific to the target CPU or GPU, GPU
+compute capability, and libtorch version. DP-GEN therefore finishes the
+training submission with the checkpoint, then runs ``freeze`` and optional
+``compress`` in a separate submission using ``model_devi_machine`` and
+``model_devi_resources``. Those resources must select the same hardware and
+software target used by all subsequent model-deviation jobs. The resulting
+models are linked into the model-deviation stage automatically.
+
+The dense PyTorch-exportable ``pte`` format remains available for non-LAMMPS
+workflows but is not supported by LAMMPS model deviation.

--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -116,9 +116,11 @@ def training_args_dp() -> list[Argument]:
         """\
         The DeePMD backend used to freeze and compress models for model
         deviation. It defaults to ``train_backend``. A model trained with
-        ``pytorch`` can be deployed with ``pytorch-exportable`` to preserve its
-        ``.pt`` training checkpoint while producing a graph-lowered ``.pt2``
-        model for model deviation. Other cross-backend exports are not supported.
+        ``pytorch`` can be deployed with ``pytorch-exportable`` and
+        ``model_format=pt2`` to preserve its ``.pt`` training checkpoint while
+        producing a graph-lowered ``.pt2`` model for model deviation. If
+        ``model_format`` is omitted, the deployment backend's default format is
+        used. Other cross-backend exports are not supported.
         """
     )
     doc_training_iter0_model_path = "The model used to init the first iter training. Number of element should be equal to numb_models."

--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -113,7 +113,16 @@ def training_args_dp() -> list[Argument]:
     )
     doc_training_iter0_model_path = "The model used to init the first iter training. Number of element should be equal to numb_models."
     doc_training_init_model = "Iteration > 0, the model parameters will be initilized from the model trained at the previous iteration. Iteration == 0, the model parameters will be initialized from training_iter0_model_path."
-    doc_default_training_param = "Training parameters for deepmd-kit in 00.train. You can find instructions from `DeePMD-kit documentation <https://docs.deepmodeling.com/projects/deepmd/>`_."
+    doc_default_training_param = textwrap.dedent(
+        """\
+        Training parameters for DeePMD-kit in 00.train. DPA4 uses
+        ``model.use_compile`` and ``model.enable_tf32`` with the PyTorch backend.
+        DPA4C uses ``training.enable_compile`` and ``training.enable_tf32`` with
+        the PyTorch-exportable backend. DP-GEN validates these locations but does
+        not inject numerical-policy settings. See the `DeePMD-kit documentation
+        <https://docs.deepmodeling.com/projects/deepmd/>`_.
+        """
+    )
     doc_dp_train_skip_neighbor_stat = "Append --skip-neighbor-stat flag to dp train."
     doc_dp_compress = "Use dp compress to compress the model."
     doc_training_reuse_iter = "The minimal index of iteration that continues training models from old models of last iteration."

--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -102,6 +102,14 @@ def training_args_dp() -> list[Argument]:
         3.2 or later.
         """
     )
+    doc_model_devi_backend = textwrap.dedent(
+        """\
+        The DeePMD-kit backend used to freeze and deploy trained checkpoints for
+        model deviation. It defaults to ``train_backend`` for backward
+        compatibility, but may be selected independently when the deployment
+        toolchain requires a different backend flag.
+        """
+    )
     doc_model_format = textwrap.dedent(
         """\
         The frozen model format. Defaults are ``pb`` for TensorFlow, ``pth`` for
@@ -161,6 +169,12 @@ def training_args_dp() -> list[Argument]:
             optional=True,
             default="tensorflow",
             doc=doc_train_backend,
+        ),
+        Argument(
+            "model_devi_backend",
+            str,
+            optional=True,
+            doc=doc_model_devi_backend,
         ),
         Argument(
             "model_format",

--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -118,7 +118,7 @@ def training_args_dp() -> list[Argument]:
         deviation. It defaults to ``train_backend``. A model trained with
         ``pytorch`` can be deployed with ``pytorch-exportable`` to preserve its
         ``.pt`` training checkpoint while producing a graph-lowered ``.pt2``
-        model for LAMMPS/Kokkos. Other cross-backend exports are not supported.
+        model for model deviation. Other cross-backend exports are not supported.
         """
     )
     doc_training_iter0_model_path = "The model used to init the first iter training. Number of element should be equal to numb_models."

--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -104,11 +104,21 @@ def training_args_dp() -> list[Argument]:
     )
     doc_model_format = textwrap.dedent(
         """\
-        The frozen model format. Defaults depend on ``train_backend``:
+        The frozen model format. Defaults depend on ``model_devi_backend`` (or
+        ``train_backend`` when no deployment backend is set):
         ``pb`` for TensorFlow, ``pth`` for PyTorch, ``pte`` for
         PyTorch-exportable, and ``savedmodel`` for JAX. PyTorch also supports
         ``pt2`` for DPA4. PyTorch-exportable supports ``pte`` and ``pt2``;
         use ``pt2`` for the graph export used by DPA4 and DPA4C.
+        """
+    )
+    doc_model_devi_backend = textwrap.dedent(
+        """\
+        The DeePMD backend used to freeze and compress models for model
+        deviation. It defaults to ``train_backend``. A model trained with
+        ``pytorch`` can be deployed with ``pytorch-exportable`` to preserve its
+        ``.pt`` training checkpoint while producing a graph-lowered ``.pt2``
+        model for LAMMPS/Kokkos. Other cross-backend exports are not supported.
         """
     )
     doc_training_iter0_model_path = "The model used to init the first iter training. Number of element should be equal to numb_models."
@@ -152,6 +162,12 @@ def training_args_dp() -> list[Argument]:
             optional=True,
             default="tensorflow",
             doc=doc_train_backend,
+        ),
+        Argument(
+            "model_devi_backend",
+            str,
+            optional=True,
+            doc=doc_model_devi_backend,
         ),
         Argument(
             "model_format",

--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -108,7 +108,9 @@ def training_args_dp() -> list[Argument]:
         PyTorch, ``pt2`` for PyTorch-exportable model deviation with LAMMPS,
         and ``savedmodel`` for JAX. PyTorch ``pt2`` is the DPA4 export;
         PyTorch-exportable ``pt2`` is the graph export used by DPA4C. The
-        PyTorch-exportable ``pte`` format is not supported by LAMMPS.
+        PyTorch-exportable ``pte`` format is not supported by LAMMPS. Freeze
+        and export use the training backend; cross-backend checkpoint conversion
+        is not supported.
         """
     )
     doc_training_iter0_model_path = "The model used to init the first iter training. Number of element should be equal to numb_models."

--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -104,23 +104,11 @@ def training_args_dp() -> list[Argument]:
     )
     doc_model_format = textwrap.dedent(
         """\
-        The frozen model format. Defaults depend on ``model_devi_backend`` (or
-        ``train_backend`` when no deployment backend is set):
-        ``pb`` for TensorFlow, ``pth`` for PyTorch, ``pte`` for
-        PyTorch-exportable, and ``savedmodel`` for JAX. PyTorch also supports
-        ``pt2`` for DPA4. PyTorch-exportable supports ``pte`` and ``pt2``;
-        use ``pt2`` for the graph export used by DPA4 and DPA4C.
-        """
-    )
-    doc_model_devi_backend = textwrap.dedent(
-        """\
-        The DeePMD backend used to freeze and compress models for model
-        deviation. It defaults to ``train_backend``. A model trained with
-        ``pytorch`` can be deployed with ``pytorch-exportable`` and
-        ``model_format=pt2`` to preserve its ``.pt`` training checkpoint while
-        producing a graph-lowered ``.pt2`` model for model deviation. If
-        ``model_format`` is omitted, the deployment backend's default format is
-        used. Other cross-backend exports are not supported.
+        The frozen model format. Defaults are ``pb`` for TensorFlow, ``pth`` for
+        PyTorch, ``pt2`` for PyTorch-exportable model deviation with LAMMPS,
+        and ``savedmodel`` for JAX. PyTorch ``pt2`` is the DPA4 export;
+        PyTorch-exportable ``pt2`` is the graph export used by DPA4C. The
+        PyTorch-exportable ``pte`` format is not supported by LAMMPS.
         """
     )
     doc_training_iter0_model_path = "The model used to init the first iter training. Number of element should be equal to numb_models."
@@ -164,12 +152,6 @@ def training_args_dp() -> list[Argument]:
             optional=True,
             default="tensorflow",
             doc=doc_train_backend,
-        ),
-        Argument(
-            "model_devi_backend",
-            str,
-            optional=True,
-            doc=doc_model_devi_backend,
         ),
         Argument(
             "model_format",

--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -94,8 +94,22 @@ def training_args_dp() -> list[Argument]:
     list[dargs.Argument]
         List of training arguments.
     """
-    doc_train_backend = (
-        "The backend of the training. Currently only support tensorflow and pytorch."
+    doc_train_backend = textwrap.dedent(
+        """\
+        The DeePMD-kit training backend. Supported values are ``tensorflow``,
+        ``pytorch``, ``pytorch-exportable`` (or its ``pt-expt`` alias), and ``jax``.
+        The PyTorch-exportable backend and DPA4 ``pt2`` export require DeePMD-kit
+        3.2 or later.
+        """
+    )
+    doc_model_format = textwrap.dedent(
+        """\
+        The frozen model format. Defaults depend on ``train_backend``:
+        ``pb`` for TensorFlow, ``pth`` for PyTorch, ``pte`` for
+        PyTorch-exportable, and ``savedmodel`` for JAX. PyTorch also supports
+        ``pt2`` for DPA4. PyTorch-exportable supports ``pte`` and ``pt2``;
+        use ``pt2`` for the graph export used by DPA4 and DPA4C.
+        """
     )
     doc_training_iter0_model_path = "The model used to init the first iter training. Number of element should be equal to numb_models."
     doc_training_init_model = "Iteration > 0, the model parameters will be initilized from the model trained at the previous iteration. Iteration == 0, the model parameters will be initialized from training_iter0_model_path."
@@ -138,6 +152,12 @@ def training_args_dp() -> list[Argument]:
             optional=True,
             default="tensorflow",
             doc=doc_train_backend,
+        ),
+        Argument(
+            "model_format",
+            str,
+            optional=True,
+            doc=doc_model_format,
         ),
         Argument(
             "training_iter0_model_path",

--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -102,14 +102,6 @@ def training_args_dp() -> list[Argument]:
         3.2 or later.
         """
     )
-    doc_model_devi_backend = textwrap.dedent(
-        """\
-        The DeePMD-kit backend used to freeze and deploy trained checkpoints for
-        model deviation. It defaults to ``train_backend`` for backward
-        compatibility, but may be selected independently when the deployment
-        toolchain requires a different backend flag.
-        """
-    )
     doc_model_format = textwrap.dedent(
         """\
         The frozen model format. Defaults are ``pb`` for TensorFlow, ``pth`` for
@@ -169,12 +161,6 @@ def training_args_dp() -> list[Argument]:
             optional=True,
             default="tensorflow",
             doc=doc_train_backend,
-        ),
-        Argument(
-            "model_devi_backend",
-            str,
-            optional=True,
-            doc=doc_model_devi_backend,
         ),
         Argument(
             "model_format",

--- a/dpgen/generator/arginfo.py
+++ b/dpgen/generator/arginfo.py
@@ -14,7 +14,18 @@ def run_mdata_arginfo() -> Argument:
     Argument
         arginfo
     """
-    return general_mdata_arginfo("run_mdata", ("train", "model_devi", "fp"))
+    arginfo = general_mdata_arginfo("run_mdata", ("train", "model_devi", "fp"))
+    train = arginfo.sub_fields["train"]
+    train.sub_fields["export_command"] = Argument(
+        "export_command",
+        str,
+        optional=True,
+        doc=(
+            "DeePMD command used to freeze and compress pt2 models on the "
+            "model-deviation machine. Defaults to train.command."
+        ),
+    )
+    return arginfo
 
 
 # basics

--- a/dpgen/generator/lib/calypso_check_outcar.py
+++ b/dpgen/generator/lib/calypso_check_outcar.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import os
 
 import numpy as np
@@ -82,11 +83,11 @@ def Write_Outcar(element, ele, volume, lat, pos, ene, force, stress, pstress):
     f.write(f"enthalpy is  TOTEN    = {enthalpy:20.6f} {enthalpy:20.6f}\n")
 
 
-def check():
+def check(model):
     from ase.io import read
     from deepmd.calculator import DP
 
-    calc = DP(model="../graph.000.pb")  # init the model before iteration
+    calc = DP(model=model)  # init the model before iteration
 
     to_be_opti = read("POSCAR")
     to_be_opti.calc = calc
@@ -118,4 +119,6 @@ def check():
 
 cwd = os.getcwd()
 if not os.path.exists(os.path.join(cwd, "OUTCAR")):
-    check()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="../graph.000.pb")
+    check(parser.parse_args().model)

--- a/dpgen/generator/lib/calypso_run_opt.py
+++ b/dpgen/generator/lib/calypso_run_opt.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import os
 import time
 
@@ -110,9 +111,9 @@ def read_stress_fmax():
     return fmax, pstress
 
 
-def run_opt(fmax, stress):
+def run_opt(fmax, stress, model):
     """Using the ASE&DP to Optimize Configures."""
-    calc = DP(model="../graph.000.pb")  # init the model before iteration
+    calc = DP(model=model)  # init the model before iteration
     os.system("mv OUTCAR OUTCAR-last")
 
     print("Start to Optimize Structures by DP----------")
@@ -164,8 +165,11 @@ def run_opt(fmax, stress):
 
 
 def run():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="../graph.000.pb")
+    args = parser.parse_args()
     fmax, stress = read_stress_fmax()
-    run_opt(fmax, stress)
+    run_opt(fmax, stress, args.model)
 
 
 if __name__ == "__main__":

--- a/dpgen/generator/lib/calypso_run_opt.py
+++ b/dpgen/generator/lib/calypso_run_opt.py
@@ -112,7 +112,21 @@ def read_stress_fmax():
 
 
 def run_opt(fmax, stress, model):
-    """Using the ASE&DP to Optimize Configures."""
+    """Optimize a CALYPSO structure with ASE and a DeePMD model.
+
+    Parameters
+    ----------
+    fmax : float
+        Maximum force convergence threshold for the ASE optimizer.
+    stress : float
+        Target external pressure in kbar.
+    model : str
+        Path to the frozen DeePMD model artifact.
+
+    Returns
+    -------
+    None
+    """
     calc = DP(model=model)  # init the model before iteration
     os.system("mv OUTCAR OUTCAR-last")
 
@@ -165,6 +179,12 @@ def run_opt(fmax, stress, model):
 
 
 def run():
+    """Run the CALYPSO optimization command-line entry point.
+
+    Returns
+    -------
+    None
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", default="../graph.000.pb")
     args = parser.parse_args()

--- a/dpgen/generator/lib/lammps.py
+++ b/dpgen/generator/lib/lammps.py
@@ -59,7 +59,7 @@ def make_lammps_input(
         while power < nbeads:
             power *= 10
         ret += "variable        ibead           uloop %d pad\n" % (power - 1)  # noqa: UP031
-    if nbeads is not None:
+    if nbeads is not None or jdata.get("model_format") == "pt2":
         ret += "atom_modify        map yes\n"
     ret += "variable        THERMO_FREQ     equal %d\n" % trj_freq  # noqa: UP031
     ret += "variable        DUMP_FREQ       equal %d\n" % trj_freq  # noqa: UP031

--- a/dpgen/generator/lib/lammps.py
+++ b/dpgen/generator/lib/lammps.py
@@ -149,15 +149,15 @@ def make_lammps_input(
             else:
                 ret += f"pair_style      deepmd {graph_list} out_freq ${{THERMO_FREQ}} out_file model_devi${{ibead}}.out {keywords}\n"
 
-    # Add pair_coeff lines
+    # Use DP-GEN's LAMMPS type order when it is available. Direct callers that
+    # omit type_map retain the historical bare pair_coeff behavior.
+    type_map_str = " ".join(jdata.get("type_map", []))
+    type_map_args = f" {type_map_str}" if type_map_str else ""
     if d3_enabled:
-        # D3 requires type maps (element symbols)
-        type_map = jdata.get("type_map", [])
-        type_map_str = " ".join(type_map)
-        ret += "pair_coeff      * * deepmd\n"
+        ret += f"pair_coeff      * * deepmd{type_map_args}\n"
         ret += f"pair_coeff      * * dispersion/d3 {type_map_str}\n"
     else:
-        ret += "pair_coeff      * *\n"
+        ret += f"pair_coeff      * *{type_map_args}\n"
     ret += "\n"
     ret += "thermo_style    custom step temp pe ke etotal press vol lx ly lz xy xz yz\n"
     ret += "thermo          ${THERMO_FREQ}\n"

--- a/dpgen/generator/lib/run_calypso.py
+++ b/dpgen/generator/lib/run_calypso.py
@@ -34,6 +34,14 @@ def _find_models(path, model_suffix=".pb"):
     return glob.glob(os.path.join(path, f"graph*{model_suffix}"))
 
 
+def _make_calypso_opt_command(deepmdkit_python, model_name):
+    """Return the CALYPSO optimization command for the resolved model."""
+    return (
+        f"{deepmdkit_python} calypso_run_opt.py --model ../{model_name} "
+        "1>> model_devi.log 2>> model_devi.log"
+    )
+
+
 def gen_structures(
     iter_index,
     jdata,
@@ -65,9 +73,7 @@ def gen_structures(
     model_names = [os.path.basename(ii) for ii in all_models]
 
     deepmdkit_python = mdata.get("model_devi_deepmdkit_python")
-    command = (
-        f"{deepmdkit_python} calypso_run_opt.py  1>> model_devi.log 2>> model_devi.log"
-    )
+    command = _make_calypso_opt_command(deepmdkit_python, sorted(model_names)[0])
     # command = "%s calypso_run_opt.py %s 1>> model_devi.log 2>> model_devi.log" % (deepmdkit_python,os.path.abspath(calypso_run_opt_path))
     # command += "  ||  %s check_outcar.py %s " % (deepmdkit_python,os.path.abspath(calypso_run_opt_path))
     command += f"  ||  {deepmdkit_python} check_outcar.py  "

--- a/dpgen/generator/lib/run_calypso.py
+++ b/dpgen/generator/lib/run_calypso.py
@@ -30,12 +30,38 @@ calypso_model_devi_name = "model_devi_results"
 
 
 def _find_models(path, model_suffix=".pb"):
-    """Return model-deviation artifacts for the resolved deployment format."""
+    """Find model-deviation artifacts for a deployment format.
+
+    Parameters
+    ----------
+    path : str or os.PathLike
+        Directory containing committee model artifacts.
+    model_suffix : str, optional
+        Resolved model filename suffix.
+
+    Returns
+    -------
+    list[str]
+        Paths matching the resolved committee model suffix.
+    """
     return glob.glob(os.path.join(path, f"graph*{model_suffix}"))
 
 
 def _make_calypso_opt_command(deepmdkit_python, model_name):
-    """Return the CALYPSO optimization command for the resolved model."""
+    """Build the CALYPSO optimization command for a resolved model.
+
+    Parameters
+    ----------
+    deepmdkit_python : str
+        Python executable used by the DeePMD environment.
+    model_name : str
+        Filename of the model artifact forwarded to CALYPSO.
+
+    Returns
+    -------
+    str
+        Shell command that invokes the optimization script.
+    """
     return (
         f"{deepmdkit_python} calypso_run_opt.py --model ../{model_name} "
         "1>> model_devi.log 2>> model_devi.log"
@@ -51,6 +77,29 @@ def gen_structures(
     length_of_caly_runopt_list,
     model_suffix=".pb",
 ):
+    """Generate and optimize one CALYPSO structure batch.
+
+    Parameters
+    ----------
+    iter_index : int
+        DP-GEN iteration index.
+    jdata : dict
+        DP-GEN workflow parameters.
+    mdata : dict
+        Machine and resource parameters.
+    caly_run_path : str
+        CALYPSO generation and optimization working directory.
+    current_idx : int
+        Index of the current CALYPSO generation.
+    length_of_caly_runopt_list : int
+        Number of CALYPSO generation directories.
+    model_suffix : str, optional
+        Resolved deployment-model suffix.
+
+    Returns
+    -------
+    None
+    """
     # run calypso
     # vsc means generate elemental, binary and ternary at the same time
     vsc = jdata.get("vsc", False)  # take CALYPSO as confs generator
@@ -353,6 +402,27 @@ def gen_structures(
 
 
 def gen_main(iter_index, jdata, mdata, caly_run_opt_list, gen_idx, model_suffix=".pb"):
+    """Run CALYPSO generation from the selected generation index.
+
+    Parameters
+    ----------
+    iter_index : int
+        DP-GEN iteration index.
+    jdata : dict
+        DP-GEN workflow parameters.
+    mdata : dict
+        Machine and resource parameters.
+    caly_run_opt_list : list[str]
+        Ordered CALYPSO generation directories.
+    gen_idx : int
+        Generation index from which to resume.
+    model_suffix : str, optional
+        Resolved deployment-model suffix.
+
+    Returns
+    -------
+    None
+    """
     iter_name = make_iter_name(iter_index)
     work_path = os.path.join(iter_name, model_devi_name)
 
@@ -472,6 +542,23 @@ def analysis(iter_index, jdata, calypso_model_devi_path):
 
 
 def run_calypso_model_devi(iter_index, jdata, mdata, model_suffix=".pb"):
+    """Run the CALYPSO model-deviation workflow.
+
+    Parameters
+    ----------
+    iter_index : int
+        DP-GEN iteration index.
+    jdata : dict
+        DP-GEN workflow parameters.
+    mdata : dict
+        Machine and resource parameters.
+    model_suffix : str, optional
+        Resolved deployment-model suffix.
+
+    Returns
+    -------
+    None
+    """
     dlog.info("start running CALYPSO")
 
     iter_name = make_iter_name(iter_index)

--- a/dpgen/generator/lib/run_calypso.py
+++ b/dpgen/generator/lib/run_calypso.py
@@ -29,8 +29,19 @@ calypso_run_opt_name = "gen_stru_analy"
 calypso_model_devi_name = "model_devi_results"
 
 
+def _find_models(path, model_suffix=".pb"):
+    """Return model-deviation artifacts for the resolved deployment format."""
+    return glob.glob(os.path.join(path, f"graph*{model_suffix}"))
+
+
 def gen_structures(
-    iter_index, jdata, mdata, caly_run_path, current_idx, length_of_caly_runopt_list
+    iter_index,
+    jdata,
+    mdata,
+    caly_run_path,
+    current_idx,
+    length_of_caly_runopt_list,
+    model_suffix=".pb",
 ):
     # run calypso
     # vsc means generate elemental, binary and ternary at the same time
@@ -50,7 +61,7 @@ def gen_structures(
     calypso_path = mdata.get("model_devi_calypso_path")
     # calypso_input_path = jdata.get('calypso_input_path')
 
-    all_models = glob.glob(os.path.join(calypso_run_opt_path, "graph*pb"))
+    all_models = _find_models(calypso_run_opt_path, model_suffix)
     model_names = [os.path.basename(ii) for ii in all_models]
 
     deepmdkit_python = mdata.get("model_devi_deepmdkit_python")
@@ -335,7 +346,7 @@ def gen_structures(
     os.chdir(cwd)
 
 
-def gen_main(iter_index, jdata, mdata, caly_run_opt_list, gen_idx):
+def gen_main(iter_index, jdata, mdata, caly_run_opt_list, gen_idx, model_suffix=".pb"):
     iter_name = make_iter_name(iter_index)
     work_path = os.path.join(iter_name, model_devi_name)
 
@@ -353,7 +364,13 @@ def gen_main(iter_index, jdata, mdata, caly_run_opt_list, gen_idx):
     for iidx, temp_path in enumerate(caly_run_opt_list):
         if iidx >= indice:
             gen_structures(
-                iter_index, jdata, mdata, temp_path, iidx, len(caly_run_opt_list)
+                iter_index,
+                jdata,
+                mdata,
+                temp_path,
+                iidx,
+                len(caly_run_opt_list),
+                model_suffix=model_suffix,
             )
 
 
@@ -448,7 +465,7 @@ def analysis(iter_index, jdata, calypso_model_devi_path):
     os.chdir(cwd)
 
 
-def run_calypso_model_devi(iter_index, jdata, mdata):
+def run_calypso_model_devi(iter_index, jdata, mdata, model_suffix=".pb"):
     dlog.info("start running CALYPSO")
 
     iter_name = make_iter_name(iter_index)
@@ -483,7 +500,14 @@ def run_calypso_model_devi(iter_index, jdata, mdata):
         if lines[-1].strip().strip("\n").split()[0] == "1":
             # Gen Structures
             gen_index = lines[-1].strip().strip("\n").split()[1]
-            gen_main(iter_index, jdata, mdata, caly_run_opt_list, gen_index)
+            gen_main(
+                iter_index,
+                jdata,
+                mdata,
+                caly_run_opt_list,
+                gen_index,
+                model_suffix=model_suffix,
+            )
 
         elif lines[-1].strip().strip("\n") == "2":
             # Analysis & to deepmd/raw
@@ -492,7 +516,7 @@ def run_calypso_model_devi(iter_index, jdata, mdata):
         elif lines[-1].strip().strip("\n") == "3":
             # Model Devi
             _calypso_run_opt_path = os.path.abspath(caly_run_opt_list[0])
-            all_models = glob.glob(os.path.join(_calypso_run_opt_path, "graph*pb"))
+            all_models = _find_models(_calypso_run_opt_path, model_suffix)
             cwd = os.getcwd()
             os.chdir(calypso_model_devi_path)
             args = " ".join(

--- a/dpgen/generator/lib/run_calypso.py
+++ b/dpgen/generator/lib/run_calypso.py
@@ -68,6 +68,24 @@ def _make_calypso_opt_command(deepmdkit_python, model_name):
     )
 
 
+def _make_calypso_check_command(deepmdkit_python, model_name):
+    """Build the CALYPSO recovery command for a resolved model.
+
+    Parameters
+    ----------
+    deepmdkit_python : str
+        Python executable used by the DeePMD environment.
+    model_name : str
+        Filename of the model artifact forwarded to CALYPSO.
+
+    Returns
+    -------
+    str
+        Shell command that invokes the CALYPSO recovery script.
+    """
+    return f"{deepmdkit_python} check_outcar.py --model ../{model_name}"
+
+
 def gen_structures(
     iter_index,
     jdata,
@@ -122,10 +140,11 @@ def gen_structures(
     model_names = [os.path.basename(ii) for ii in all_models]
 
     deepmdkit_python = mdata.get("model_devi_deepmdkit_python")
-    command = _make_calypso_opt_command(deepmdkit_python, sorted(model_names)[0])
+    model_name = sorted(model_names)[0]
+    command = _make_calypso_opt_command(deepmdkit_python, model_name)
     # command = "%s calypso_run_opt.py %s 1>> model_devi.log 2>> model_devi.log" % (deepmdkit_python,os.path.abspath(calypso_run_opt_path))
     # command += "  ||  %s check_outcar.py %s " % (deepmdkit_python,os.path.abspath(calypso_run_opt_path))
-    command += f"  ||  {deepmdkit_python} check_outcar.py  "
+    command += f"  ||  {_make_calypso_check_command(deepmdkit_python, model_name)}"
     commands = [command]
 
     cwd = os.getcwd()

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -125,21 +125,84 @@ check_outcar_file = os.path.join(ROOT_PATH, "generator/lib/calypso_check_outcar.
 run_opt_file = os.path.join(ROOT_PATH, "generator/lib/calypso_run_opt.py")
 
 
-def _get_model_suffix(jdata) -> str:
-    """Return the model suffix based on the backend."""
+_BACKEND_ALIASES = {"pt-expt": "pytorch-exportable"}
+_BACKEND_CONFIG = {
+    "tensorflow": {
+        "flag": "",
+        "checkpoint_suffix": ".index",
+        "default_model_format": "pb",
+        "model_formats": {"pb"},
+    },
+    "pytorch": {
+        "flag": "--pt",
+        "checkpoint_suffix": ".pt",
+        "default_model_format": "pth",
+        "model_formats": {"pth", "pt2"},
+    },
+    "pytorch-exportable": {
+        "flag": "--pt-expt",
+        "checkpoint_suffix": ".pt",
+        "default_model_format": "pte",
+        "model_formats": {"pte", "pt2"},
+    },
+    "jax": {
+        "flag": "--jax",
+        "checkpoint_suffix": ".jax",
+        "default_model_format": "savedmodel",
+        "model_formats": {"savedmodel"},
+    },
+}
+
+
+def _get_backend_config(jdata) -> tuple[str, dict, str]:
+    """Return and validate the DeePMD backend and deployment format."""
     mlp_engine = jdata.get("mlp_engine", "dp")
-    if mlp_engine == "dp":
-        suffix_map = {"tensorflow": ".pb", "pytorch": ".pth", "jax": ".savedmodel"}
-        backend = jdata.get("train_backend", "tensorflow")
-        if backend in suffix_map:
-            suffix = suffix_map[backend]
-        else:
-            raise ValueError(
-                f"The backend {backend} is not available. Supported backends are: 'tensorflow', 'pytorch', 'jax'."
-            )
-        return suffix
-    else:
+    if mlp_engine != "dp":
         raise ValueError(f"Unsupported engine: {mlp_engine}")
+
+    backend = jdata.get("train_backend", "tensorflow")
+    backend = _BACKEND_ALIASES.get(backend, backend)
+    if backend not in _BACKEND_CONFIG:
+        supported = "', '".join(_BACKEND_CONFIG)
+        raise ValueError(
+            f"The backend {backend} is not available. Supported backends are: '{supported}'."
+        )
+
+    config = _BACKEND_CONFIG[backend]
+    model_format = jdata.get("model_format", config["default_model_format"])
+    if model_format not in config["model_formats"]:
+        supported = "', '".join(sorted(config["model_formats"]))
+        raise ValueError(
+            f"The model format {model_format} is not available for backend {backend}. "
+            f"Supported formats are: '{supported}'."
+        )
+    return backend, config, model_format
+
+
+def _get_model_suffix(jdata) -> str:
+    """Return the frozen model suffix."""
+    _, _, model_format = _get_backend_config(jdata)
+    return f".{model_format}"
+
+
+def _get_checkpoint_suffix(jdata) -> str:
+    """Return the training checkpoint suffix."""
+    _, config, _ = _get_backend_config(jdata)
+    return config["checkpoint_suffix"]
+
+
+def _get_train_backend_flag(jdata) -> str:
+    """Return the DeePMD CLI backend flag."""
+    _, config, _ = _get_backend_config(jdata)
+    return config["flag"]
+
+
+def _get_input_model_suffix(models) -> str:
+    """Return the common suffix of input models."""
+    suffixes = {Path(model).suffix.lower() for model in models}
+    if "" in suffixes or len(suffixes) != 1:
+        raise ValueError("Input models must have the same non-empty file suffix.")
+    return suffixes.pop()
 
 
 def get_job_names(jdata):
@@ -667,9 +730,13 @@ def make_train_dp(iter_index, jdata, mdata):
         None,
     )
     if copied_models is not None:
+        input_model_suffix = _get_input_model_suffix(copied_models)
         for ii in range(len(copied_models)):
             _link_old_models(
-                work_path, [copied_models[ii]], ii, basename=f"init{suffix}"
+                work_path,
+                [copied_models[ii]],
+                ii,
+                basename=f"init{input_model_suffix}",
             )
     # Copy user defined forward files
     symlink_user_forward_files(mdata=mdata, task_type="train", work_path=work_path)
@@ -730,7 +797,9 @@ def run_train_dp(iter_index, jdata, mdata):
     # print("debug:run_train:mdata", mdata)
     # load json param
     numb_models = jdata["numb_models"]
+    backend, _, model_format = _get_backend_config(jdata)
     suffix = _get_model_suffix(jdata)
+    checkpoint_suffix = _get_checkpoint_suffix(jdata)
     # train_param = jdata['train_param']
     train_input_file = default_train_input_file
     training_reuse_iter = jdata.get("training_reuse_iter")
@@ -752,6 +821,27 @@ def run_train_dp(iter_index, jdata, mdata):
     except KeyError:
         mdata = set_version(mdata)
 
+    if (backend == "pytorch-exportable" or model_format == "pt2") and Version(
+        mdata["deepmd_version"]
+    ) < Version("3.2"):
+        raise RuntimeError(
+            "The pytorch-exportable backend and pt2 models require DeePMD-kit 3.2 or later."
+        )
+    if backend == "pytorch-exportable" and training_init_frozen_model is not None:
+        raise RuntimeError(
+            "The pytorch-exportable backend does not support training_init_frozen_model; "
+            "use training_finetune_model or a checkpoint instead."
+        )
+    if (
+        backend == "pytorch"
+        and model_format == "pt2"
+        and jdata.get("dp_compress", False)
+    ):
+        raise RuntimeError(
+            "The pytorch backend cannot compress pt2 models; use "
+            "pytorch-exportable for a compressible pt2 model."
+        )
+
     if (
         training_init_model
         + (training_init_frozen_model is not None)
@@ -764,10 +854,9 @@ def run_train_dp(iter_index, jdata, mdata):
 
     train_command = mdata.get("train_command", "dp").strip()
     # assert train_command == "dp", "The 'train_command' should be 'dp'"     # the tests should be updated to run this command
-    if suffix == ".pth":
-        train_command += " --pt"
-    elif suffix == ".savedmodel":
-        train_command += " --jax"
+    backend_flag = _get_train_backend_flag(jdata)
+    if backend_flag:
+        train_command += f" {backend_flag}"
 
     # paths
     iter_name = make_iter_name(iter_index)
@@ -797,25 +886,32 @@ def run_train_dp(iter_index, jdata, mdata):
         if training_init_model:
             init_flag = " --init-model old/model.ckpt"
         elif training_init_frozen_model is not None:
-            init_flag = f" --init-frz-model old/init{suffix}"
+            input_model_suffix = _get_input_model_suffix(training_init_frozen_model)
+            init_flag = f" --init-frz-model old/init{input_model_suffix}"
         elif training_finetune_model is not None:
-            init_flag = f" --finetune old/init{suffix}"
+            input_model_suffix = _get_input_model_suffix(training_finetune_model)
+            init_flag = f" --finetune old/init{input_model_suffix}"
         command = f"{train_command} train {train_input_file}{extra_flags}"
-        if suffix == ".pb":
-            ckpt_suffix = ".index"
-        elif suffix == ".pth":
-            ckpt_suffix = ".pt"
-        elif suffix == ".savedmodel":
-            ckpt_suffix = ".jax"
-        else:
-            raise RuntimeError(f"Unknown suffix {suffix}")
-        command = f"{{ if [ ! -f model.ckpt{ckpt_suffix} ]; then {command}{init_flag}; else {command} --restart model.ckpt; fi }}"
+        command = f"{{ if [ ! -f model.ckpt{checkpoint_suffix} ]; then {command}{init_flag}; else {command} --restart model.ckpt; fi }}"
         command = f"/bin/sh -c {shlex.quote(command)}"
         commands.append(command)
-        command = f"{train_command} freeze"
+        if backend == "pytorch-exportable":
+            command = f"{train_command} freeze -o frozen_model{suffix}"
+            if model_format == "pt2":
+                command += " --lower-kind graph"
+        elif backend == "pytorch" and model_format == "pt2":
+            command = f"{train_command} freeze -o frozen_model{suffix}"
+        else:
+            command = f"{train_command} freeze"
         commands.append(command)
         if jdata.get("dp_compress", False):
-            commands.append(f"{train_command} compress")
+            if backend == "pytorch-exportable":
+                commands.append(
+                    f"{train_command} compress -i frozen_model{suffix} "
+                    f"-o frozen_model_compressed{suffix}"
+                )
+            else:
+                commands.append(f"{train_command} compress")
     else:
         raise RuntimeError(
             "DP-GEN currently only supports for DeePMD-kit 1.x to 3.x version!"
@@ -836,20 +932,26 @@ def run_train_dp(iter_index, jdata, mdata):
     if "srtab_file_path" in jdata.keys():
         forward_files.append(zbl_file)
     if training_init_model:
-        if suffix == ".pb":
+        if checkpoint_suffix == ".index":
             forward_files += [
                 os.path.join("old", "model.ckpt.meta"),
                 os.path.join("old", "model.ckpt.index"),
                 os.path.join("old", "model.ckpt.data-00000-of-00001"),
             ]
-        elif suffix == ".pth":
+        elif checkpoint_suffix == ".pt":
             forward_files += [os.path.join("old", "model.ckpt.pt")]
-        elif suffix == ".savedmodel":
+        elif checkpoint_suffix == ".jax":
             forward_files += [os.path.join("old", "model.ckpt.jax")]
         else:
-            raise RuntimeError(f"Unknown suffix {suffix}")
+            raise RuntimeError(f"Unknown checkpoint suffix {checkpoint_suffix}")
     elif training_init_frozen_model is not None or training_finetune_model is not None:
-        forward_files.append(os.path.join("old", f"init{suffix}"))
+        input_models = (
+            training_init_frozen_model
+            if training_init_frozen_model is not None
+            else training_finetune_model
+        )
+        input_model_suffix = _get_input_model_suffix(input_models)
+        forward_files.append(os.path.join("old", f"init{input_model_suffix}"))
 
     backward_files = [
         f"frozen_model{suffix}",
@@ -860,18 +962,18 @@ def run_train_dp(iter_index, jdata, mdata):
     if jdata.get("dp_compress", False):
         backward_files.append(f"frozen_model_compressed{suffix}")
 
-    if suffix == ".pb":
+    if checkpoint_suffix == ".index":
         backward_files += [
             "model.ckpt.meta",
             "model.ckpt.index",
             "model.ckpt.data-00000-of-00001",
         ]
-    elif suffix == ".pth":
+    elif checkpoint_suffix == ".pt":
         backward_files += ["model.ckpt.pt"]
-    elif suffix == ".savedmodel":
+    elif checkpoint_suffix == ".jax":
         backward_files += ["model.ckpt.jax"]
     else:
-        raise RuntimeError(f"Unknown suffix {suffix}")
+        raise RuntimeError(f"Unknown checkpoint suffix {checkpoint_suffix}")
 
     if not jdata.get("one_h5", False):
         init_data_sys_ = jdata["init_data_sys"]

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -1373,40 +1373,69 @@ def revise_lmp_input_model(
 
 
 def revise_lmp_input_pair_coeff(lmp_lines, jdata=None):
-    """Update pair_coeff lines for D3 support."""
+    """Add explicit DeepMD element mapping and D3 pair coefficients."""
     if jdata is None:
         return lmp_lines
 
     lmp_d3 = jdata.get("lmp_d3", {})
     d3_enabled = lmp_d3.get("enable", False) if lmp_d3 else False
-
-    if not d3_enabled:
-        return lmp_lines
-
-    # D3 requires type maps (element symbols)
     type_map = jdata.get("type_map", [])
     type_map_str = " ".join(type_map)
+    type_map_args = f" {type_map_str}" if type_map_str else ""
 
-    # Find pair_coeff line
-    pair_coeff_idx = None
+    if not d3_enabled and not type_map:
+        return lmp_lines
+
+    deepmd_coeff_idx = None
+    d3_coeff_idx = None
     for idx, line in enumerate(lmp_lines):
-        if line.strip().startswith("pair_coeff") and "* *" in line:
-            pair_coeff_idx = idx
-            break
+        tokens = line.partition("#")[0].split()
+        if not tokens or tokens[0] != "pair_coeff":
+            continue
+        if "dispersion/d3" in tokens:
+            d3_coeff_idx = idx
+        elif deepmd_coeff_idx is None:
+            deepmd_coeff_idx = idx
 
-    if pair_coeff_idx is None:
-        # If no pair_coeff found, add them after pair_style
+    if deepmd_coeff_idx is None:
         pair_style_idx = find_only_one_key(lmp_lines, ["pair_style"])
-        lmp_lines.insert(pair_style_idx + 1, "pair_coeff      * * deepmd\n")
-        lmp_lines.insert(
-            pair_style_idx + 2, f"pair_coeff      * * dispersion/d3 {type_map_str}\n"
-        )
+        deepmd_coeff_idx = pair_style_idx + 1
+        if d3_enabled:
+            line = f"pair_coeff      * * deepmd{type_map_args}\n"
+        else:
+            line = f"pair_coeff      * *{type_map_args}\n"
+        lmp_lines.insert(deepmd_coeff_idx, line)
+        if d3_coeff_idx is not None and d3_coeff_idx >= deepmd_coeff_idx:
+            d3_coeff_idx += 1
     else:
-        # Replace existing pair_coeff with D3 version
-        lmp_lines[pair_coeff_idx] = "pair_coeff      * * deepmd\n"
-        lmp_lines.insert(
-            pair_coeff_idx + 1, f"pair_coeff      * * dispersion/d3 {type_map_str}\n"
+        tokens = lmp_lines[deepmd_coeff_idx].partition("#")[0].split()
+        bare_coeff = tokens in (
+            ["pair_coeff"],
+            ["pair_coeff", "*", "*"],
+            ["pair_coeff", "*", "*", "deepmd"],
         )
+        if d3_enabled:
+            if tokens[:3] == ["pair_coeff", "*", "*"]:
+                if tokens[3:4] == ["deepmd"]:
+                    elements = tokens[4:]
+                else:
+                    elements = tokens[3:]
+            else:
+                elements = []
+            element_args = f" {' '.join(elements)}" if elements else type_map_args
+            lmp_lines[deepmd_coeff_idx] = f"pair_coeff      * * deepmd{element_args}\n"
+        elif bare_coeff:
+            style = " deepmd" if tokens[3:4] == ["deepmd"] else ""
+            lmp_lines[deepmd_coeff_idx] = f"pair_coeff      * *{style}{type_map_args}\n"
+
+    if d3_enabled:
+        d3_line = f"pair_coeff      * * dispersion/d3 {type_map_str}\n"
+        if d3_coeff_idx is None:
+            lmp_lines.insert(deepmd_coeff_idx + 1, d3_line)
+        else:
+            d3_tokens = lmp_lines[d3_coeff_idx].partition("#")[0].split()
+            if d3_tokens == ["pair_coeff", "*", "*", "dispersion/d3"]:
+                lmp_lines[d3_coeff_idx] = d3_line
 
     return lmp_lines
 

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -177,8 +177,7 @@ def _get_train_backend_config(jdata) -> tuple[str, dict]:
 
 def _get_model_backend_config(jdata) -> tuple[str, dict, str]:
     """Return and validate the deployment backend and model format."""
-    train_backend, _ = _get_train_backend_config(jdata)
-    backend, config = _get_backend(jdata, "model_devi_backend", train_backend)
+    backend, config = _get_train_backend_config(jdata)
     default_model_format = config["default_model_format"]
     if (
         backend == "pytorch-exportable"
@@ -218,12 +217,6 @@ def _get_checkpoint_suffix(jdata) -> str:
 def _get_train_backend_flag(jdata) -> str:
     """Return the DeePMD CLI backend flag."""
     _, config = _get_train_backend_config(jdata)
-    return config["flag"]
-
-
-def _get_model_backend_flag(jdata) -> str:
-    """Return the DeePMD CLI flag used for model export and deployment."""
-    _, config, _ = _get_model_backend_config(jdata)
     return config["flag"]
 
 
@@ -272,32 +265,19 @@ def _validate_dpa_training_config(jdata) -> None:
     """Validate DPA4/DPA4C backend and acceleration-option placement."""
     training_param = jdata.get("default_training_param", {})
     family = _get_dpa_model_family(training_param)
-    train_backend, _ = _get_train_backend_config(jdata)
-    model_backend, _, model_format = _get_model_backend_config(jdata)
     if family is None:
-        if (
-            train_backend == "pytorch"
-            and model_backend == "pytorch"
-            and model_format == "pt2"
-        ):
-            raise ValueError(
-                "The regular PyTorch backend only exports pt2 for DPA4/SeZM models."
-            )
         return
 
+    train_backend, _ = _get_train_backend_config(jdata)
     expected_backend = "pytorch" if family == "dpa4" else "pytorch-exportable"
     if train_backend != expected_backend:
         raise ValueError(
             f"{family.upper()} training requires train_backend='{expected_backend}', "
             f"not '{train_backend}'"
         )
-    if model_backend != expected_backend:
-        raise ValueError(
-            f"{family.upper()} deployment requires model_devi_backend="
-            f"'{expected_backend}', not '{model_backend}'"
-        )
 
     if jdata.get("model_devi_engine", "lammps") == "lammps":
+        _, _, model_format = _get_model_backend_config(jdata)
         if model_format != "pt2":
             raise ValueError(
                 f"{family.upper()} LAMMPS model deviation requires model_format='pt2'"
@@ -922,7 +902,7 @@ def run_train_dp(iter_index, jdata, mdata):
     _validate_dpa_training_config(jdata)
     numb_models = jdata["numb_models"]
     train_backend, _ = _get_train_backend_config(jdata)
-    model_backend, _, model_format = _get_model_backend_config(jdata)
+    _, _, model_format = _get_model_backend_config(jdata)
     suffix = _get_model_suffix(jdata)
     checkpoint_suffix = _get_checkpoint_suffix(jdata)
     # train_param = jdata['train_param']
@@ -946,9 +926,9 @@ def run_train_dp(iter_index, jdata, mdata):
     except KeyError:
         mdata = set_version(mdata)
 
-    if (
-        "pytorch-exportable" in {train_backend, model_backend} or model_format == "pt2"
-    ) and Version(mdata["deepmd_version"]) < Version("3.2"):
+    if (train_backend == "pytorch-exportable" or model_format == "pt2") and Version(
+        mdata["deepmd_version"]
+    ) < Version("3.2"):
         raise RuntimeError(
             "The pytorch-exportable backend and pt2 models require DeePMD-kit 3.2 or later."
         )
@@ -958,7 +938,7 @@ def run_train_dp(iter_index, jdata, mdata):
             "use training_finetune_model or a checkpoint instead."
         )
     if (
-        model_backend == "pytorch"
+        train_backend == "pytorch"
         and model_format == "pt2"
         and jdata.get("dp_compress", False)
     ):
@@ -977,16 +957,11 @@ def run_train_dp(iter_index, jdata, mdata):
             "training_init_model, training_init_frozen_model, and training_finetune_model are mutually exclusive."
         )
 
-    deepmd_command = mdata.get("train_command", "dp").strip()
+    train_command = mdata.get("train_command", "dp").strip()
     # assert train_command == "dp", "The 'train_command' should be 'dp'"     # the tests should be updated to run this command
-    train_command = deepmd_command
-    train_backend_flag = _get_train_backend_flag(jdata)
-    if train_backend_flag:
-        train_command += f" {train_backend_flag}"
-    model_command = deepmd_command
-    model_backend_flag = _get_model_backend_flag(jdata)
-    if model_backend_flag:
-        model_command += f" {model_backend_flag}"
+    backend_flag = _get_train_backend_flag(jdata)
+    if backend_flag:
+        train_command += f" {backend_flag}"
 
     # paths
     iter_name = make_iter_name(iter_index)
@@ -1027,33 +1002,33 @@ def run_train_dp(iter_index, jdata, mdata):
         command = f"/bin/sh -c {shlex.quote(command)}"
         commands.append(command)
         if model_format == "pt2":
-            if model_backend == "pytorch-exportable":
+            if train_backend == "pytorch-exportable":
                 command = (
-                    f"{model_command} freeze -c model.ckpt.pt -o frozen_model "
+                    f"{train_command} freeze -c model.ckpt.pt -o frozen_model "
                     "--lower-kind graph"
                 )
             else:
-                command = f"{model_command} freeze -c model.ckpt.pt -o frozen_model"
+                command = f"{train_command} freeze -c model.ckpt.pt -o frozen_model"
             export_commands.append(command)
             if jdata.get("dp_compress", False):
                 export_commands.append(
-                    f"{model_command} compress -i frozen_model{suffix} "
+                    f"{train_command} compress -i frozen_model{suffix} "
                     f"-o frozen_model_compressed{suffix}"
                 )
         else:
-            if model_backend == "pytorch-exportable":
-                command = f"{model_command} freeze -o frozen_model{suffix}"
+            if train_backend == "pytorch-exportable":
+                command = f"{train_command} freeze -o frozen_model{suffix}"
             else:
-                command = f"{model_command} freeze"
+                command = f"{train_command} freeze"
             commands.append(command)
             if jdata.get("dp_compress", False):
-                if model_backend == "pytorch-exportable":
+                if train_backend == "pytorch-exportable":
                     commands.append(
-                        f"{model_command} compress -i frozen_model{suffix} "
+                        f"{train_command} compress -i frozen_model{suffix} "
                         f"-o frozen_model_compressed{suffix}"
                     )
                 else:
-                    commands.append(f"{model_command} compress")
+                    commands.append(f"{train_command} compress")
     else:
         raise RuntimeError(
             "DP-GEN currently only supports for DeePMD-kit 1.x to 3.x version!"

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -1621,7 +1621,19 @@ def make_model_devi(iter_index, jdata, mdata):
 
 
 def _validate_pt2_template_atom_map(lmp_lines):
-    """Validate the atom map required by pt2 LAMMPS templates."""
+    """Validate the atom map required by pt2 LAMMPS templates.
+
+    Parameters
+    ----------
+    lmp_lines : list[str]
+        Lines of the LAMMPS input template.
+
+    Raises
+    ------
+    ValueError
+        If ``atom_modify map yes`` is missing or follows ``read_data`` or
+        ``read_restart``.
+    """
     atom_map_index = None
     read_index = None
     for line_index, line in enumerate(lmp_lines):
@@ -1738,7 +1750,7 @@ def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
                 # revise input of lammps
                 with open("input.lammps") as fp:
                     lmp_lines = fp.readlines()
-                if jdata.get("model_format") == "pt2":
+                if suffix == ".pt2":
                     _validate_pt2_template_atom_map(lmp_lines)
                 # only revise the line "pair_style deepmd" if the user has not written the full line (checked by then length of the line)
                 template_has_pair_deepmd = 1

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -177,21 +177,27 @@ def _get_train_backend_config(jdata) -> tuple[str, dict]:
 
 def _get_model_backend_config(jdata) -> tuple[str, dict, str]:
     """Return and validate the deployment backend and model format."""
-    train_backend, _ = _get_train_backend_config(jdata)
-    backend, config = _get_backend(jdata, "model_devi_backend", train_backend)
-    if backend != train_backend and not (
-        train_backend == "pytorch" and backend == "pytorch-exportable"
+    backend, config = _get_train_backend_config(jdata)
+    default_model_format = config["default_model_format"]
+    if (
+        backend == "pytorch-exportable"
+        and jdata.get("model_devi_engine", "lammps") == "lammps"
     ):
-        raise ValueError(
-            f"Cannot export models trained with backend {train_backend} using "
-            f"backend {backend}."
-        )
-    model_format = jdata.get("model_format", config["default_model_format"])
+        default_model_format = "pt2"
+    model_format = jdata.get("model_format", default_model_format)
     if model_format not in config["model_formats"]:
         supported = "', '".join(sorted(config["model_formats"]))
         raise ValueError(
             f"The model format {model_format} is not available for backend {backend}. "
             f"Supported formats are: '{supported}'."
+        )
+    if (
+        backend == "pytorch-exportable"
+        and model_format == "pte"
+        and jdata.get("model_devi_engine", "lammps") == "lammps"
+    ):
+        raise ValueError(
+            "The pte model format is not supported by LAMMPS; use model_format=pt2."
         )
     return backend, config, model_format
 
@@ -211,12 +217,6 @@ def _get_checkpoint_suffix(jdata) -> str:
 def _get_train_backend_flag(jdata) -> str:
     """Return the DeePMD CLI backend flag."""
     _, config = _get_train_backend_config(jdata)
-    return config["flag"]
-
-
-def _get_model_backend_flag(jdata) -> str:
-    """Return the DeePMD CLI deployment backend flag."""
-    _, config, _ = _get_model_backend_config(jdata)
     return config["flag"]
 
 
@@ -821,7 +821,7 @@ def run_train_dp(iter_index, jdata, mdata):
     # load json param
     numb_models = jdata["numb_models"]
     train_backend, _ = _get_train_backend_config(jdata)
-    model_backend, _, model_format = _get_model_backend_config(jdata)
+    _, _, model_format = _get_model_backend_config(jdata)
     suffix = _get_model_suffix(jdata)
     checkpoint_suffix = _get_checkpoint_suffix(jdata)
     # train_param = jdata['train_param']
@@ -845,11 +845,9 @@ def run_train_dp(iter_index, jdata, mdata):
     except KeyError:
         mdata = set_version(mdata)
 
-    if (
-        train_backend == "pytorch-exportable"
-        or model_backend == "pytorch-exportable"
-        or model_format == "pt2"
-    ) and Version(mdata["deepmd_version"]) < Version("3.2"):
+    if (train_backend == "pytorch-exportable" or model_format == "pt2") and Version(
+        mdata["deepmd_version"]
+    ) < Version("3.2"):
         raise RuntimeError(
             "The pytorch-exportable backend and pt2 models require DeePMD-kit 3.2 or later."
         )
@@ -859,7 +857,7 @@ def run_train_dp(iter_index, jdata, mdata):
             "use training_finetune_model or a checkpoint instead."
         )
     if (
-        model_backend == "pytorch"
+        train_backend == "pytorch"
         and model_format == "pt2"
         and jdata.get("dp_compress", False)
     ):
@@ -883,10 +881,6 @@ def run_train_dp(iter_index, jdata, mdata):
     backend_flag = _get_train_backend_flag(jdata)
     if backend_flag:
         train_command += f" {backend_flag}"
-    model_command = mdata.get("train_command", "dp").strip()
-    model_backend_flag = _get_model_backend_flag(jdata)
-    if model_backend_flag:
-        model_command += f" {model_backend_flag}"
 
     # paths
     iter_name = make_iter_name(iter_index)
@@ -902,6 +896,7 @@ def run_train_dp(iter_index, jdata, mdata):
         task_path = os.path.join(work_path, train_task_fmt % ii)
         all_task.append(task_path)
     commands = []
+    export_commands = []
     if Version(mdata["deepmd_version"]) >= Version("1") and Version(
         mdata["deepmd_version"]
     ) < Version("4"):
@@ -925,23 +920,34 @@ def run_train_dp(iter_index, jdata, mdata):
         command = f"{{ if [ ! -f model.ckpt{checkpoint_suffix} ]; then {command}{init_flag}; else {command} --restart model.ckpt; fi }}"
         command = f"/bin/sh -c {shlex.quote(command)}"
         commands.append(command)
-        if model_backend == "pytorch-exportable":
-            command = f"{model_command} freeze -o frozen_model{suffix}"
-            if model_format == "pt2":
-                command += " --lower-kind graph"
-        elif model_backend == "pytorch" and model_format == "pt2":
-            command = f"{model_command} freeze -o frozen_model{suffix}"
-        else:
-            command = f"{model_command} freeze"
-        commands.append(command)
-        if jdata.get("dp_compress", False):
-            if model_backend == "pytorch-exportable":
-                commands.append(
-                    f"{model_command} compress -i frozen_model{suffix} "
-                    f"-o frozen_model_compressed{suffix}"
+        if model_format == "pt2":
+            if train_backend == "pytorch-exportable":
+                command = (
+                    f"{train_command} freeze -c model.ckpt.pt -o frozen_model "
+                    "--lower-kind graph"
                 )
             else:
-                commands.append(f"{model_command} compress")
+                command = f"{train_command} freeze -c model.ckpt.pt -o frozen_model"
+            export_commands.append(command)
+            if jdata.get("dp_compress", False):
+                export_commands.append(
+                    f"{train_command} compress -i frozen_model{suffix} "
+                    f"-o frozen_model_compressed{suffix}"
+                )
+        else:
+            if train_backend == "pytorch-exportable":
+                command = f"{train_command} freeze -o frozen_model{suffix}"
+            else:
+                command = f"{train_command} freeze"
+            commands.append(command)
+            if jdata.get("dp_compress", False):
+                if train_backend == "pytorch-exportable":
+                    commands.append(
+                        f"{train_command} compress -i frozen_model{suffix} "
+                        f"-o frozen_model_compressed{suffix}"
+                    )
+                else:
+                    commands.append(f"{train_command} compress")
     else:
         raise RuntimeError(
             "DP-GEN currently only supports for DeePMD-kit 1.x to 3.x version!"
@@ -984,13 +990,14 @@ def run_train_dp(iter_index, jdata, mdata):
         forward_files.append(os.path.join("old", f"init{input_model_suffix}"))
 
     backward_files = [
-        f"frozen_model{suffix}",
         "lcurve.out",
         "train.log",
         "checkpoint",
     ]
-    if jdata.get("dp_compress", False):
-        backward_files.append(f"frozen_model_compressed{suffix}")
+    if not export_commands:
+        backward_files.append(f"frozen_model{suffix}")
+        if jdata.get("dp_compress", False):
+            backward_files.append(f"frozen_model_compressed{suffix}")
 
     if checkpoint_suffix == ".index":
         backward_files += [
@@ -1057,6 +1064,24 @@ def run_train_dp(iter_index, jdata, mdata):
         errlog="train.log",
     )
     submission.run_submission()
+    if export_commands:
+        export_backward_files = [f"frozen_model{suffix}"]
+        if jdata.get("dp_compress", False):
+            export_backward_files.append(f"frozen_model_compressed{suffix}")
+        export_submission = make_submission(
+            mdata["model_devi_machine"],
+            mdata["model_devi_resources"],
+            commands=export_commands,
+            work_path=work_path,
+            run_tasks=run_tasks,
+            group_size=1,
+            forward_common_files=[],
+            forward_files=[f"model.ckpt{checkpoint_suffix}"],
+            backward_files=export_backward_files,
+            outlog="model_export.log",
+            errlog="model_export.log",
+        )
+        export_submission.run_submission()
 
 
 def post_train(iter_index, jdata, mdata):
@@ -1595,6 +1620,29 @@ def make_model_devi(iter_index, jdata, mdata):
     return True
 
 
+def _validate_pt2_template_atom_map(lmp_lines):
+    """Validate the atom map required by pt2 LAMMPS templates."""
+    atom_map_index = None
+    read_index = None
+    for line_index, line in enumerate(lmp_lines):
+        tokens = line.partition("#")[0].split()
+        if not tokens:
+            continue
+        if tokens[0] == "atom_modify" and any(
+            tokens[index : index + 2] == ["map", "yes"]
+            for index in range(1, len(tokens) - 1)
+        ):
+            atom_map_index = line_index
+        elif tokens[0] in {"read_data", "read_restart"} and read_index is None:
+            read_index = line_index
+    if atom_map_index is None or (
+        read_index is not None and atom_map_index > read_index
+    ):
+        raise ValueError(
+            "pt2 LAMMPS templates require 'atom_modify map yes' before read_data or read_restart."
+        )
+
+
 def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
     model_devi_jobs = jdata["model_devi_jobs"]
     if iter_index >= len(model_devi_jobs):
@@ -1690,6 +1738,8 @@ def _make_model_devi_revmat(iter_index, jdata, mdata, conf_systems):
                 # revise input of lammps
                 with open("input.lammps") as fp:
                     lmp_lines = fp.readlines()
+                if jdata.get("model_format") == "pt2":
+                    _validate_pt2_template_atom_map(lmp_lines)
                 # only revise the line "pair_style deepmd" if the user has not written the full line (checked by then length of the line)
                 template_has_pair_deepmd = 1
                 for line_idx, line_context in enumerate(lmp_lines):

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -1970,7 +1970,7 @@ def _make_model_devi_native(iter_index, jdata, mdata, conf_systems):
                         trj_freq,
                         mass_map,
                         tt,
-                        jdata=jdata,
+                        jdata={**jdata, "model_format": suffix[1:]},
                         tau_t=model_devi_taut,
                         pres=pp,
                         tau_p=model_devi_taup,

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -229,6 +229,18 @@ def _get_input_model_suffix(models) -> str:
 
 
 def _iter_model_sections(training_param):
+    """Yield the top-level model and each model-dictionary branch.
+
+    Parameters
+    ----------
+    training_param : dict
+        DeePMD training parameters.
+
+    Yields
+    ------
+    tuple[str, dict]
+        The dotted configuration path and corresponding model section.
+    """
     model = training_param.get("model", {})
     yield "model", model
     for name, branch in (model.get("model_dict") or {}).items():
@@ -236,6 +248,23 @@ def _iter_model_sections(training_param):
 
 
 def _get_dpa_model_family(training_param) -> Optional[str]:
+    """Identify the DPA model family in a training configuration.
+
+    Parameters
+    ----------
+    training_param : dict
+        DeePMD training parameters.
+
+    Returns
+    -------
+    str or None
+        "dpa4", "dpa4c", or None when neither family is present.
+
+    Raises
+    ------
+    ValueError
+        If DPA4 and DPA4C branches are mixed in one configuration.
+    """
     families = set()
     for _, model in _iter_model_sections(training_param):
         model_type = model.get("type")
@@ -262,7 +291,23 @@ def _get_dpa_model_family(training_param) -> Optional[str]:
 
 
 def _validate_dpa_training_config(jdata) -> None:
-    """Validate DPA4/DPA4C backend and acceleration-option placement."""
+    """Validate DPA backend, format, and acceleration-option placement.
+
+    Parameters
+    ----------
+    jdata : dict
+        DP-GEN parameters containing the training and deployment configuration.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ValueError
+        If the model family, backend, deployment format, or acceleration
+        options are incompatible.
+    """
     training_param = jdata.get("default_training_param", {})
     family = _get_dpa_model_family(training_param)
     train_backend, _ = _get_train_backend_config(jdata)
@@ -1373,7 +1418,26 @@ def revise_lmp_input_model(
 
 
 def revise_lmp_input_pair_coeff(lmp_lines, jdata=None):
-    """Add explicit DeepMD element mapping and D3 pair coefficients."""
+    """Add explicit DeepMD element mapping and D3 pair coefficients.
+
+    Parameters
+    ----------
+    lmp_lines : list[str]
+        Lines from a LAMMPS input template.
+    jdata : dict, optional
+        DP-GEN parameters, including type_map and optional D3 settings.
+
+    Returns
+    -------
+    list[str]
+        The updated LAMMPS input lines.
+
+    Raises
+    ------
+    RuntimeError
+        If a coefficient must be inserted but the template does not contain
+        exactly one pair_style line.
+    """
     if jdata is None:
         return lmp_lines
 
@@ -1386,7 +1450,12 @@ def revise_lmp_input_pair_coeff(lmp_lines, jdata=None):
     if not d3_enabled and not type_map:
         return lmp_lines
 
+    pair_style_idx = find_only_one_key(lmp_lines, ["pair_style"])
+    pair_style_tokens = lmp_lines[pair_style_idx].partition("#")[0].split()
+    hybrid_pair_style = pair_style_tokens[1].startswith("hybrid")
+
     deepmd_coeff_idx = None
+    fallback_coeff_idx = None
     d3_coeff_idx = None
     for idx, line in enumerate(lmp_lines):
         tokens = line.partition("#")[0].split()
@@ -1394,16 +1463,24 @@ def revise_lmp_input_pair_coeff(lmp_lines, jdata=None):
             continue
         if "dispersion/d3" in tokens:
             d3_coeff_idx = idx
-        elif deepmd_coeff_idx is None:
+        elif tokens[3:4] == ["deepmd"] and deepmd_coeff_idx is None:
             deepmd_coeff_idx = idx
+        elif fallback_coeff_idx is None:
+            fallback_coeff_idx = idx
+
+    if deepmd_coeff_idx is None and fallback_coeff_idx is not None:
+        fallback_tokens = lmp_lines[fallback_coeff_idx].partition("#")[0].split()
+        fallback_is_bare = fallback_tokens in (
+            ["pair_coeff"],
+            ["pair_coeff", "*", "*"],
+        )
+        if not hybrid_pair_style or (d3_enabled and fallback_is_bare):
+            deepmd_coeff_idx = fallback_coeff_idx
 
     if deepmd_coeff_idx is None:
-        pair_style_idx = find_only_one_key(lmp_lines, ["pair_style"])
         deepmd_coeff_idx = pair_style_idx + 1
-        if d3_enabled:
-            line = f"pair_coeff      * * deepmd{type_map_args}\n"
-        else:
-            line = f"pair_coeff      * *{type_map_args}\n"
+        style = " deepmd" if d3_enabled or hybrid_pair_style else ""
+        line = f"pair_coeff      * *{style}{type_map_args}\n"
         lmp_lines.insert(deepmd_coeff_idx, line)
         if d3_coeff_idx is not None and d3_coeff_idx >= deepmd_coeff_idx:
             d3_coeff_idx += 1

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -177,7 +177,8 @@ def _get_train_backend_config(jdata) -> tuple[str, dict]:
 
 def _get_model_backend_config(jdata) -> tuple[str, dict, str]:
     """Return and validate the deployment backend and model format."""
-    backend, config = _get_train_backend_config(jdata)
+    train_backend, _ = _get_train_backend_config(jdata)
+    backend, config = _get_backend(jdata, "model_devi_backend", train_backend)
     default_model_format = config["default_model_format"]
     if (
         backend == "pytorch-exportable"
@@ -217,6 +218,12 @@ def _get_checkpoint_suffix(jdata) -> str:
 def _get_train_backend_flag(jdata) -> str:
     """Return the DeePMD CLI backend flag."""
     _, config = _get_train_backend_config(jdata)
+    return config["flag"]
+
+
+def _get_model_backend_flag(jdata) -> str:
+    """Return the DeePMD CLI flag used for model export and deployment."""
+    _, config, _ = _get_model_backend_config(jdata)
     return config["flag"]
 
 
@@ -265,19 +272,32 @@ def _validate_dpa_training_config(jdata) -> None:
     """Validate DPA4/DPA4C backend and acceleration-option placement."""
     training_param = jdata.get("default_training_param", {})
     family = _get_dpa_model_family(training_param)
+    train_backend, _ = _get_train_backend_config(jdata)
+    model_backend, _, model_format = _get_model_backend_config(jdata)
     if family is None:
+        if (
+            train_backend == "pytorch"
+            and model_backend == "pytorch"
+            and model_format == "pt2"
+        ):
+            raise ValueError(
+                "The regular PyTorch backend only exports pt2 for DPA4/SeZM models."
+            )
         return
 
-    train_backend, _ = _get_train_backend_config(jdata)
     expected_backend = "pytorch" if family == "dpa4" else "pytorch-exportable"
     if train_backend != expected_backend:
         raise ValueError(
             f"{family.upper()} training requires train_backend='{expected_backend}', "
             f"not '{train_backend}'"
         )
+    if model_backend != expected_backend:
+        raise ValueError(
+            f"{family.upper()} deployment requires model_devi_backend="
+            f"'{expected_backend}', not '{model_backend}'"
+        )
 
     if jdata.get("model_devi_engine", "lammps") == "lammps":
-        _, _, model_format = _get_model_backend_config(jdata)
         if model_format != "pt2":
             raise ValueError(
                 f"{family.upper()} LAMMPS model deviation requires model_format='pt2'"
@@ -902,7 +922,7 @@ def run_train_dp(iter_index, jdata, mdata):
     _validate_dpa_training_config(jdata)
     numb_models = jdata["numb_models"]
     train_backend, _ = _get_train_backend_config(jdata)
-    _, _, model_format = _get_model_backend_config(jdata)
+    model_backend, _, model_format = _get_model_backend_config(jdata)
     suffix = _get_model_suffix(jdata)
     checkpoint_suffix = _get_checkpoint_suffix(jdata)
     # train_param = jdata['train_param']
@@ -926,9 +946,9 @@ def run_train_dp(iter_index, jdata, mdata):
     except KeyError:
         mdata = set_version(mdata)
 
-    if (train_backend == "pytorch-exportable" or model_format == "pt2") and Version(
-        mdata["deepmd_version"]
-    ) < Version("3.2"):
+    if (
+        "pytorch-exportable" in {train_backend, model_backend} or model_format == "pt2"
+    ) and Version(mdata["deepmd_version"]) < Version("3.2"):
         raise RuntimeError(
             "The pytorch-exportable backend and pt2 models require DeePMD-kit 3.2 or later."
         )
@@ -938,7 +958,7 @@ def run_train_dp(iter_index, jdata, mdata):
             "use training_finetune_model or a checkpoint instead."
         )
     if (
-        train_backend == "pytorch"
+        model_backend == "pytorch"
         and model_format == "pt2"
         and jdata.get("dp_compress", False)
     ):
@@ -957,11 +977,16 @@ def run_train_dp(iter_index, jdata, mdata):
             "training_init_model, training_init_frozen_model, and training_finetune_model are mutually exclusive."
         )
 
-    train_command = mdata.get("train_command", "dp").strip()
+    deepmd_command = mdata.get("train_command", "dp").strip()
     # assert train_command == "dp", "The 'train_command' should be 'dp'"     # the tests should be updated to run this command
-    backend_flag = _get_train_backend_flag(jdata)
-    if backend_flag:
-        train_command += f" {backend_flag}"
+    train_command = deepmd_command
+    train_backend_flag = _get_train_backend_flag(jdata)
+    if train_backend_flag:
+        train_command += f" {train_backend_flag}"
+    model_command = deepmd_command
+    model_backend_flag = _get_model_backend_flag(jdata)
+    if model_backend_flag:
+        model_command += f" {model_backend_flag}"
 
     # paths
     iter_name = make_iter_name(iter_index)
@@ -1002,33 +1027,33 @@ def run_train_dp(iter_index, jdata, mdata):
         command = f"/bin/sh -c {shlex.quote(command)}"
         commands.append(command)
         if model_format == "pt2":
-            if train_backend == "pytorch-exportable":
+            if model_backend == "pytorch-exportable":
                 command = (
-                    f"{train_command} freeze -c model.ckpt.pt -o frozen_model "
+                    f"{model_command} freeze -c model.ckpt.pt -o frozen_model "
                     "--lower-kind graph"
                 )
             else:
-                command = f"{train_command} freeze -c model.ckpt.pt -o frozen_model"
+                command = f"{model_command} freeze -c model.ckpt.pt -o frozen_model"
             export_commands.append(command)
             if jdata.get("dp_compress", False):
                 export_commands.append(
-                    f"{train_command} compress -i frozen_model{suffix} "
+                    f"{model_command} compress -i frozen_model{suffix} "
                     f"-o frozen_model_compressed{suffix}"
                 )
         else:
-            if train_backend == "pytorch-exportable":
-                command = f"{train_command} freeze -o frozen_model{suffix}"
+            if model_backend == "pytorch-exportable":
+                command = f"{model_command} freeze -o frozen_model{suffix}"
             else:
-                command = f"{train_command} freeze"
+                command = f"{model_command} freeze"
             commands.append(command)
             if jdata.get("dp_compress", False):
-                if train_backend == "pytorch-exportable":
+                if model_backend == "pytorch-exportable":
                     commands.append(
-                        f"{train_command} compress -i frozen_model{suffix} "
+                        f"{model_command} compress -i frozen_model{suffix} "
                         f"-o frozen_model_compressed{suffix}"
                     )
                 else:
-                    commands.append(f"{train_command} compress")
+                    commands.append(f"{model_command} compress")
     else:
         raise RuntimeError(
             "DP-GEN currently only supports for DeePMD-kit 1.x to 3.x version!"

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -228,6 +228,86 @@ def _get_input_model_suffix(models) -> str:
     return suffixes.pop()
 
 
+def _iter_model_sections(training_param):
+    model = training_param.get("model", {})
+    yield "model", model
+    for name, branch in (model.get("model_dict") or {}).items():
+        yield f"model.model_dict.{name}", branch
+
+
+def _get_dpa_model_family(training_param) -> Optional[str]:
+    families = set()
+    for _, model in _iter_model_sections(training_param):
+        model_type = model.get("type")
+        descriptor = model.get("descriptor", {})
+        descriptor_type = (
+            descriptor.get("type") if isinstance(descriptor, dict) else None
+        )
+        model_type = model_type.lower() if isinstance(model_type, str) else model_type
+        descriptor_type = (
+            descriptor_type.lower()
+            if isinstance(descriptor_type, str)
+            else descriptor_type
+        )
+        if descriptor_type == "dpa4c":
+            families.add("dpa4c")
+        if model_type == "dpa4" or descriptor_type in {"dpa4", "sezm"}:
+            families.add("dpa4")
+    if len(families) > 1:
+        raise ValueError(
+            "default_training_param cannot mix DPA4 and DPA4C branches because "
+            "they require different DeePMD backends"
+        )
+    return next(iter(families), None)
+
+
+def _validate_dpa_training_config(jdata) -> None:
+    """Validate DPA4/DPA4C backend and acceleration-option placement."""
+    training_param = jdata.get("default_training_param", {})
+    family = _get_dpa_model_family(training_param)
+    if family is None:
+        return
+
+    train_backend, _ = _get_train_backend_config(jdata)
+    expected_backend = "pytorch" if family == "dpa4" else "pytorch-exportable"
+    if train_backend != expected_backend:
+        raise ValueError(
+            f"{family.upper()} training requires train_backend='{expected_backend}', "
+            f"not '{train_backend}'"
+        )
+
+    if jdata.get("model_devi_engine", "lammps") == "lammps":
+        _, _, model_format = _get_model_backend_config(jdata)
+        if model_format != "pt2":
+            raise ValueError(
+                f"{family.upper()} LAMMPS model deviation requires model_format='pt2'"
+            )
+
+    if family == "dpa4c":
+        misplaced = []
+        for scope, model in _iter_model_sections(training_param):
+            for key in ("use_compile", "enable_tf32"):
+                if key in model:
+                    misplaced.append(f"{scope}.{key}")
+        if misplaced:
+            raise ValueError(
+                "DPA4C uses training.enable_compile and training.enable_tf32; "
+                f"remove misplaced {', '.join(misplaced)}"
+            )
+    else:
+        training = training_param.get("training", {})
+        misplaced = [
+            f"training.{key}"
+            for key in ("enable_compile", "enable_tf32")
+            if key in training
+        ]
+        if misplaced:
+            raise ValueError(
+                "DPA4 uses model.use_compile and model.enable_tf32; "
+                f"remove misplaced {', '.join(misplaced)}"
+            )
+
+
 def get_job_names(jdata):
     jobkeys = []
     for ii in jdata.keys():
@@ -819,6 +899,7 @@ def run_train(iter_index, jdata, mdata):
 def run_train_dp(iter_index, jdata, mdata):
     # print("debug:run_train:mdata", mdata)
     # load json param
+    _validate_dpa_training_config(jdata)
     numb_models = jdata["numb_models"]
     train_backend, _ = _get_train_backend_config(jdata)
     _, _, model_format = _get_model_backend_config(jdata)
@@ -1637,7 +1718,8 @@ def _validate_pt2_template_atom_map(lmp_lines):
     atom_map_index = None
     read_index = None
     for line_index, line in enumerate(lmp_lines):
-        tokens = line.partition("#")[0].split()
+        command = line.partition("#")[0]
+        tokens = command.split()
         if not tokens:
             continue
         if tokens[0] == "atom_modify" and any(
@@ -1645,11 +1727,11 @@ def _validate_pt2_template_atom_map(lmp_lines):
             for index in range(1, len(tokens) - 1)
         ):
             atom_map_index = line_index
-        elif tokens[0] in {"read_data", "read_restart"} and read_index is None:
+        if read_index is None and re.search(r"\bread_(?:data|restart)\b", command):
             read_index = line_index
-    if atom_map_index is None or (
-        read_index is not None and atom_map_index > read_index
-    ):
+    if read_index is None:
+        raise ValueError("pt2 LAMMPS templates require read_data or read_restart.")
+    if atom_map_index is None or atom_map_index > read_index:
         raise ValueError(
             "pt2 LAMMPS templates require 'atom_modify map yes' before read_data or read_restart."
         )
@@ -2475,7 +2557,12 @@ def run_model_devi(iter_index, jdata, mdata):
     if model_devi_engine != "calypso":
         run_md_model_devi(iter_index, jdata, mdata)
     else:
-        run_calypso_model_devi(iter_index, jdata, mdata)
+        run_calypso_model_devi(
+            iter_index,
+            jdata,
+            mdata,
+            model_suffix=_get_model_suffix(jdata),
+        )
 
 
 def post_model_devi(iter_index, jdata, mdata):

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -176,7 +176,7 @@ def _get_train_backend_config(jdata) -> tuple[str, dict]:
 
 
 def _get_model_backend_config(jdata) -> tuple[str, dict, str]:
-    """Return and validate the deployment backend and model format."""
+    """Return the training backend and validate its frozen model format."""
     backend, config = _get_train_backend_config(jdata)
     default_model_format = config["default_model_format"]
     if (
@@ -251,7 +251,7 @@ def _get_dpa_model_family(training_param) -> Optional[str]:
         )
         if descriptor_type == "dpa4c":
             families.add("dpa4c")
-        if model_type == "dpa4" or descriptor_type in {"dpa4", "sezm"}:
+        if model_type in {"dpa4", "sezm"} or descriptor_type in {"dpa4", "sezm"}:
             families.add("dpa4")
     if len(families) > 1:
         raise ValueError(
@@ -265,10 +265,14 @@ def _validate_dpa_training_config(jdata) -> None:
     """Validate DPA4/DPA4C backend and acceleration-option placement."""
     training_param = jdata.get("default_training_param", {})
     family = _get_dpa_model_family(training_param)
-    if family is None:
-        return
-
     train_backend, _ = _get_train_backend_config(jdata)
+    _, _, model_format = _get_model_backend_config(jdata)
+    if family is None:
+        if train_backend == "pytorch" and model_format == "pt2":
+            raise ValueError(
+                "The regular PyTorch backend only exports pt2 for DPA4/SeZM models."
+            )
+        return
     expected_backend = "pytorch" if family == "dpa4" else "pytorch-exportable"
     if train_backend != expected_backend:
         raise ValueError(
@@ -277,7 +281,6 @@ def _validate_dpa_training_config(jdata) -> None:
         )
 
     if jdata.get("model_devi_engine", "lammps") == "lammps":
-        _, _, model_format = _get_model_backend_config(jdata)
         if model_format != "pt2":
             raise ValueError(
                 f"{family.upper()} LAMMPS model deviation requires model_format='pt2'"

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -154,21 +154,38 @@ _BACKEND_CONFIG = {
 }
 
 
-def _get_backend_config(jdata) -> tuple[str, dict, str]:
-    """Return and validate the DeePMD backend and deployment format."""
+def _get_backend(jdata, key, default) -> tuple[str, dict]:
+    """Return and validate a DeePMD backend."""
     mlp_engine = jdata.get("mlp_engine", "dp")
     if mlp_engine != "dp":
         raise ValueError(f"Unsupported engine: {mlp_engine}")
 
-    backend = jdata.get("train_backend", "tensorflow")
+    backend = jdata.get(key, default)
     backend = _BACKEND_ALIASES.get(backend, backend)
     if backend not in _BACKEND_CONFIG:
         supported = "', '".join(_BACKEND_CONFIG)
         raise ValueError(
             f"The backend {backend} is not available. Supported backends are: '{supported}'."
         )
+    return backend, _BACKEND_CONFIG[backend]
 
-    config = _BACKEND_CONFIG[backend]
+
+def _get_train_backend_config(jdata) -> tuple[str, dict]:
+    """Return the training backend configuration."""
+    return _get_backend(jdata, "train_backend", "tensorflow")
+
+
+def _get_model_backend_config(jdata) -> tuple[str, dict, str]:
+    """Return and validate the deployment backend and model format."""
+    train_backend, _ = _get_train_backend_config(jdata)
+    backend, config = _get_backend(jdata, "model_devi_backend", train_backend)
+    if backend != train_backend and not (
+        train_backend == "pytorch" and backend == "pytorch-exportable"
+    ):
+        raise ValueError(
+            f"Cannot export models trained with backend {train_backend} using "
+            f"backend {backend}."
+        )
     model_format = jdata.get("model_format", config["default_model_format"])
     if model_format not in config["model_formats"]:
         supported = "', '".join(sorted(config["model_formats"]))
@@ -181,19 +198,25 @@ def _get_backend_config(jdata) -> tuple[str, dict, str]:
 
 def _get_model_suffix(jdata) -> str:
     """Return the frozen model suffix."""
-    _, _, model_format = _get_backend_config(jdata)
+    _, _, model_format = _get_model_backend_config(jdata)
     return f".{model_format}"
 
 
 def _get_checkpoint_suffix(jdata) -> str:
     """Return the training checkpoint suffix."""
-    _, config, _ = _get_backend_config(jdata)
+    _, config = _get_train_backend_config(jdata)
     return config["checkpoint_suffix"]
 
 
 def _get_train_backend_flag(jdata) -> str:
     """Return the DeePMD CLI backend flag."""
-    _, config, _ = _get_backend_config(jdata)
+    _, config = _get_train_backend_config(jdata)
+    return config["flag"]
+
+
+def _get_model_backend_flag(jdata) -> str:
+    """Return the DeePMD CLI deployment backend flag."""
+    _, config, _ = _get_model_backend_config(jdata)
     return config["flag"]
 
 
@@ -797,7 +820,8 @@ def run_train_dp(iter_index, jdata, mdata):
     # print("debug:run_train:mdata", mdata)
     # load json param
     numb_models = jdata["numb_models"]
-    backend, _, model_format = _get_backend_config(jdata)
+    train_backend, _ = _get_train_backend_config(jdata)
+    model_backend, _, model_format = _get_model_backend_config(jdata)
     suffix = _get_model_suffix(jdata)
     checkpoint_suffix = _get_checkpoint_suffix(jdata)
     # train_param = jdata['train_param']
@@ -821,19 +845,21 @@ def run_train_dp(iter_index, jdata, mdata):
     except KeyError:
         mdata = set_version(mdata)
 
-    if (backend == "pytorch-exportable" or model_format == "pt2") and Version(
-        mdata["deepmd_version"]
-    ) < Version("3.2"):
+    if (
+        train_backend == "pytorch-exportable"
+        or model_backend == "pytorch-exportable"
+        or model_format == "pt2"
+    ) and Version(mdata["deepmd_version"]) < Version("3.2"):
         raise RuntimeError(
             "The pytorch-exportable backend and pt2 models require DeePMD-kit 3.2 or later."
         )
-    if backend == "pytorch-exportable" and training_init_frozen_model is not None:
+    if train_backend == "pytorch-exportable" and training_init_frozen_model is not None:
         raise RuntimeError(
             "The pytorch-exportable backend does not support training_init_frozen_model; "
             "use training_finetune_model or a checkpoint instead."
         )
     if (
-        backend == "pytorch"
+        model_backend == "pytorch"
         and model_format == "pt2"
         and jdata.get("dp_compress", False)
     ):
@@ -857,6 +883,10 @@ def run_train_dp(iter_index, jdata, mdata):
     backend_flag = _get_train_backend_flag(jdata)
     if backend_flag:
         train_command += f" {backend_flag}"
+    model_command = mdata.get("train_command", "dp").strip()
+    model_backend_flag = _get_model_backend_flag(jdata)
+    if model_backend_flag:
+        model_command += f" {model_backend_flag}"
 
     # paths
     iter_name = make_iter_name(iter_index)
@@ -895,23 +925,23 @@ def run_train_dp(iter_index, jdata, mdata):
         command = f"{{ if [ ! -f model.ckpt{checkpoint_suffix} ]; then {command}{init_flag}; else {command} --restart model.ckpt; fi }}"
         command = f"/bin/sh -c {shlex.quote(command)}"
         commands.append(command)
-        if backend == "pytorch-exportable":
-            command = f"{train_command} freeze -o frozen_model{suffix}"
+        if model_backend == "pytorch-exportable":
+            command = f"{model_command} freeze -o frozen_model{suffix}"
             if model_format == "pt2":
                 command += " --lower-kind graph"
-        elif backend == "pytorch" and model_format == "pt2":
-            command = f"{train_command} freeze -o frozen_model{suffix}"
+        elif model_backend == "pytorch" and model_format == "pt2":
+            command = f"{model_command} freeze -o frozen_model{suffix}"
         else:
-            command = f"{train_command} freeze"
+            command = f"{model_command} freeze"
         commands.append(command)
         if jdata.get("dp_compress", False):
-            if backend == "pytorch-exportable":
+            if model_backend == "pytorch-exportable":
                 commands.append(
-                    f"{train_command} compress -i frozen_model{suffix} "
+                    f"{model_command} compress -i frozen_model{suffix} "
                     f"-o frozen_model_compressed{suffix}"
                 )
             else:
-                commands.append(f"{train_command} compress")
+                commands.append(f"{model_command} compress")
     else:
         raise RuntimeError(
             "DP-GEN currently only supports for DeePMD-kit 1.x to 3.x version!"

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -220,6 +220,29 @@ def _get_train_backend_flag(jdata) -> str:
     return config["flag"]
 
 
+def _get_export_command(mdata, backend_flag) -> str:
+    """Return the deployment-side DeePMD export command.
+
+    Parameters
+    ----------
+    mdata : dict
+        Machine configuration, optionally including ``train_export_command``.
+    backend_flag : str
+        DeePMD CLI flag required by the training checkpoint backend.
+
+    Returns
+    -------
+    str
+        Deployment-side DeePMD command with the required backend flag.
+    """
+    export_command = mdata.get(
+        "train_export_command", mdata.get("train_command", "dp")
+    ).strip()
+    if backend_flag:
+        export_command += f" {backend_flag}"
+    return export_command
+
+
 def _get_input_model_suffix(models) -> str:
     """Return the common suffix of input models."""
     suffixes = {Path(model).suffix.lower() for model in models}
@@ -1010,6 +1033,7 @@ def run_train_dp(iter_index, jdata, mdata):
     backend_flag = _get_train_backend_flag(jdata)
     if backend_flag:
         train_command += f" {backend_flag}"
+    export_command = _get_export_command(mdata, backend_flag)
 
     # paths
     iter_name = make_iter_name(iter_index)
@@ -1052,15 +1076,15 @@ def run_train_dp(iter_index, jdata, mdata):
         if model_format == "pt2":
             if train_backend == "pytorch-exportable":
                 command = (
-                    f"{train_command} freeze -c model.ckpt.pt -o frozen_model "
+                    f"{export_command} freeze -c model.ckpt.pt -o frozen_model "
                     "--lower-kind graph"
                 )
             else:
-                command = f"{train_command} freeze -c model.ckpt.pt -o frozen_model"
+                command = f"{export_command} freeze -c model.ckpt.pt -o frozen_model"
             export_commands.append(command)
             if jdata.get("dp_compress", False):
                 export_commands.append(
-                    f"{train_command} compress -i frozen_model{suffix} "
+                    f"{export_command} compress -i frozen_model{suffix} "
                     f"-o frozen_model_compressed{suffix}"
                 )
         else:
@@ -1179,20 +1203,27 @@ def run_train_dp(iter_index, jdata, mdata):
     ### Submit jobs
     check_api_version(mdata)
 
-    submission = make_submission(
-        mdata["train_machine"],
-        mdata["train_resources"],
-        commands=commands,
-        work_path=work_path,
-        run_tasks=run_tasks,
-        group_size=train_group_size,
-        forward_common_files=trans_comm_data,
-        forward_files=forward_files,
-        backward_files=backward_files,
-        outlog="train.log",
-        errlog="train.log",
+    checkpoints_complete = export_commands and all(
+        os.path.isfile(os.path.join(task, f"model.ckpt{checkpoint_suffix}"))
+        for task in all_task
     )
-    submission.run_submission()
+    if checkpoints_complete:
+        log_task("training checkpoints found, skip training and retry model export")
+    else:
+        submission = make_submission(
+            mdata["train_machine"],
+            mdata["train_resources"],
+            commands=commands,
+            work_path=work_path,
+            run_tasks=run_tasks,
+            group_size=train_group_size,
+            forward_common_files=trans_comm_data,
+            forward_files=forward_files,
+            backward_files=backward_files,
+            outlog="train.log",
+            errlog="train.log",
+        )
+        submission.run_submission()
     if export_commands:
         export_backward_files = [f"frozen_model{suffix}"]
         if jdata.get("dp_compress", False):
@@ -1821,8 +1852,8 @@ def _validate_pt2_template_atom_map(lmp_lines):
     Raises
     ------
     ValueError
-        If ``atom_modify map yes`` is missing or follows ``read_data`` or
-        ``read_restart``.
+        If ``atom_modify map yes``, ``array``, or ``hash`` is missing or
+        follows ``read_data`` or ``read_restart``.
     """
     atom_map_index = None
     read_index = None
@@ -1832,7 +1863,7 @@ def _validate_pt2_template_atom_map(lmp_lines):
         if not tokens:
             continue
         if tokens[0] == "atom_modify" and any(
-            tokens[index : index + 2] == ["map", "yes"]
+            tokens[index] == "map" and tokens[index + 1] in {"yes", "array", "hash"}
             for index in range(1, len(tokens) - 1)
         ):
             atom_map_index = line_index
@@ -1842,7 +1873,8 @@ def _validate_pt2_template_atom_map(lmp_lines):
         raise ValueError("pt2 LAMMPS templates require read_data or read_restart.")
     if atom_map_index is None or atom_map_index > read_index:
         raise ValueError(
-            "pt2 LAMMPS templates require 'atom_modify map yes' before read_data or read_restart."
+            "pt2 LAMMPS templates require 'atom_modify map yes', 'array', or "
+            "'hash' before read_data or read_restart."
         )
 
 

--- a/tests/generator/test_deepmd_backend.py
+++ b/tests/generator/test_deepmd_backend.py
@@ -1,0 +1,161 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from dpgen.generator.run import (
+    _get_checkpoint_suffix,
+    _get_input_model_suffix,
+    _get_model_suffix,
+    _get_train_backend_flag,
+    post_train_dp,
+    run_train_dp,
+)
+
+
+class TestDeepmdBackendConfig(unittest.TestCase):
+    def test_legacy_defaults(self):
+        cases = [
+            ({}, ".pb", ".index", ""),
+            ({"train_backend": "pytorch"}, ".pth", ".pt", "--pt"),
+            ({"train_backend": "jax"}, ".savedmodel", ".jax", "--jax"),
+        ]
+        for jdata, model_suffix, checkpoint_suffix, backend_flag in cases:
+            with self.subTest(jdata=jdata):
+                self.assertEqual(_get_model_suffix(jdata), model_suffix)
+                self.assertEqual(_get_checkpoint_suffix(jdata), checkpoint_suffix)
+                self.assertEqual(_get_train_backend_flag(jdata), backend_flag)
+
+    def test_pytorch_exportable_aliases(self):
+        for backend in ("pytorch-exportable", "pt-expt"):
+            with self.subTest(backend=backend):
+                jdata = {"train_backend": backend}
+                self.assertEqual(_get_model_suffix(jdata), ".pte")
+                self.assertEqual(_get_checkpoint_suffix(jdata), ".pt")
+                self.assertEqual(_get_train_backend_flag(jdata), "--pt-expt")
+
+    def test_explicit_pt2_formats(self):
+        for backend in ("pytorch", "pytorch-exportable", "pt-expt"):
+            with self.subTest(backend=backend):
+                jdata = {"train_backend": backend, "model_format": "pt2"}
+                self.assertEqual(_get_model_suffix(jdata), ".pt2")
+                self.assertEqual(_get_checkpoint_suffix(jdata), ".pt")
+
+    def test_rejects_incompatible_model_format(self):
+        with self.assertRaisesRegex(ValueError, "not available for backend"):
+            _get_model_suffix({"train_backend": "tensorflow", "model_format": "pt2"})
+
+    def test_input_models_must_share_suffix(self):
+        self.assertEqual(_get_input_model_suffix(["a.pt", "b.pt"]), ".pt")
+        with self.assertRaisesRegex(ValueError, "same non-empty file suffix"):
+            _get_input_model_suffix(["a.pte", "b.pt2"])
+
+
+class TestRunTrainDeepmdBackend(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.old_cwd = os.getcwd()
+        os.chdir(self.tmp.name)
+        self.addCleanup(os.chdir, self.old_cwd)
+        self.mdata = {
+            "api_version": "1.0",
+            "deepmd_version": "3.2.0",
+            "train_command": "dp",
+            "train_machine": {},
+            "train_resources": {},
+        }
+
+    def _run(self, **updates):
+        jdata = {"numb_models": 1, "one_h5": True}
+        jdata.update(updates)
+        with patch("dpgen.generator.run.make_submission") as make_submission:
+            run_train_dp(0, jdata, self.mdata)
+        return make_submission.call_args.kwargs
+
+    def test_legacy_tensorflow_commands_are_preserved(self):
+        call = self._run()
+        self.assertIn("model.ckpt.index", call["commands"][0])
+        self.assertEqual(call["commands"][1], "dp freeze")
+        self.assertIn("frozen_model.pb", call["backward_files"])
+        self.assertIn("model.ckpt.index", call["backward_files"])
+
+    def test_regular_pytorch_dpa4_pt2(self):
+        call = self._run(train_backend="pytorch", model_format="pt2")
+        self.assertIn("dp --pt train", call["commands"][0])
+        self.assertIn("model.ckpt.pt", call["commands"][0])
+        self.assertEqual(call["commands"][1], "dp --pt freeze -o frozen_model.pt2")
+        self.assertIn("frozen_model.pt2", call["backward_files"])
+        self.assertIn("model.ckpt.pt", call["backward_files"])
+
+    def test_legacy_pytorch_commands_are_preserved(self):
+        call = self._run(train_backend="pytorch")
+        self.assertIn("dp --pt train", call["commands"][0])
+        self.assertIn("model.ckpt.pt", call["commands"][0])
+        self.assertEqual(call["commands"][1], "dp --pt freeze")
+        self.assertIn("frozen_model.pth", call["backward_files"])
+        self.assertIn("model.ckpt.pt", call["backward_files"])
+
+    def test_pytorch_exportable_dense_pte(self):
+        call = self._run(train_backend="pytorch-exportable")
+        self.assertIn("dp --pt-expt train", call["commands"][0])
+        self.assertEqual(
+            call["commands"][1],
+            "dp --pt-expt freeze -o frozen_model.pte",
+        )
+        self.assertIn("frozen_model.pte", call["backward_files"])
+
+    def test_pytorch_exportable_dpa4c_pt2_compression(self):
+        call = self._run(train_backend="pt-expt", model_format="pt2", dp_compress=True)
+        self.assertEqual(
+            call["commands"][1],
+            "dp --pt-expt freeze -o frozen_model.pt2 --lower-kind graph",
+        )
+        self.assertEqual(
+            call["commands"][2],
+            "dp --pt-expt compress -i frozen_model.pt2 -o frozen_model_compressed.pt2",
+        )
+        self.assertIn("frozen_model_compressed.pt2", call["backward_files"])
+
+    def test_regular_pytorch_pt2_compression_is_rejected(self):
+        with self.assertRaisesRegex(RuntimeError, "cannot compress pt2"):
+            self._run(train_backend="pytorch", model_format="pt2", dp_compress=True)
+
+    def test_exportable_init_frozen_model_is_rejected(self):
+        with self.assertRaisesRegex(RuntimeError, "does not support"):
+            self._run(
+                train_backend="pt-expt",
+                training_init_frozen_model=["model.pt2"],
+            )
+
+    def test_deepmd_31_is_rejected_for_pt2(self):
+        self.mdata["deepmd_version"] = "3.1.0"
+        with self.assertRaisesRegex(RuntimeError, "3.2 or later"):
+            self._run(train_backend="pytorch", model_format="pt2")
+
+    def test_finetune_keeps_source_model_suffix(self):
+        call = self._run(
+            train_backend="pt-expt",
+            model_format="pt2",
+            training_finetune_model=["source.pt"],
+        )
+        self.assertIn("--finetune old/init.pt", call["commands"][0])
+        self.assertIn(str(Path("old") / "init.pt"), call["forward_files"])
+
+    def test_post_train_links_pt2_model(self):
+        jdata = {
+            "numb_models": 1,
+            "train_backend": "pt-expt",
+            "model_format": "pt2",
+        }
+        with patch("dpgen.generator.run.os.symlink") as symlink:
+            post_train_dp(0, jdata, self.mdata)
+        symlink.assert_called_once_with(
+            str(Path("000") / "frozen_model.pt2"),
+            str(Path("iter.000000") / "00.train" / "graph.000.pt2"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/generator/test_deepmd_backend.py
+++ b/tests/generator/test_deepmd_backend.py
@@ -9,6 +9,7 @@ from dpgen.generator.lib.run_calypso import _find_models
 from dpgen.generator.run import (
     _get_checkpoint_suffix,
     _get_input_model_suffix,
+    _get_model_backend_flag,
     _get_model_suffix,
     _get_train_backend_flag,
     _validate_dpa_training_config,
@@ -39,6 +40,17 @@ class TestDeepmdBackendConfig(unittest.TestCase):
                 self.assertEqual(_get_model_suffix(jdata), ".pt2")
                 self.assertEqual(_get_checkpoint_suffix(jdata), ".pt")
                 self.assertEqual(_get_train_backend_flag(jdata), "--pt-expt")
+
+    def test_model_deviation_backend_is_independent(self):
+        jdata = {
+            "train_backend": "pytorch",
+            "model_devi_backend": "pytorch-exportable",
+            "model_format": "pt2",
+        }
+        self.assertEqual(_get_checkpoint_suffix(jdata), ".pt")
+        self.assertEqual(_get_train_backend_flag(jdata), "--pt")
+        self.assertEqual(_get_model_backend_flag(jdata), "--pt-expt")
+        self.assertEqual(_get_model_suffix(jdata), ".pt2")
 
     def test_explicit_pt2_formats(self):
         cases = [
@@ -210,6 +222,10 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         train_call, export_call = self._run(
             train_backend="pytorch",
             model_format="pt2",
+            default_training_param={
+                "model": {"descriptor": {"type": "sezm"}},
+                "training": {},
+            },
         )
         self.assertEqual(train_call["machine"], self.mdata["train_machine"])
         self.assertEqual(len(train_call["commands"]), 1)
@@ -224,6 +240,18 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         )
         self.assertEqual(export_call["forward_files"], ["model.ckpt.pt"])
         self.assertIn("frozen_model.pt2", export_call["backward_files"])
+
+    def test_separate_model_backend_controls_export_command(self):
+        train_call, export_call = self._run(
+            train_backend="pytorch",
+            model_devi_backend="pytorch-exportable",
+            model_format="pt2",
+        )
+        self.assertIn("dp --pt train", train_call["commands"][0])
+        self.assertEqual(
+            export_call["commands"],
+            ["dp --pt-expt freeze -c model.ckpt.pt -o frozen_model --lower-kind graph"],
+        )
 
     def test_legacy_pytorch_commands_are_preserved(self):
         call = self._run(train_backend="pytorch")
@@ -274,7 +302,19 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
 
     def test_regular_pytorch_pt2_compression_is_rejected(self):
         with self.assertRaisesRegex(RuntimeError, "cannot compress pt2"):
-            self._run(train_backend="pytorch", model_format="pt2", dp_compress=True)
+            self._run(
+                train_backend="pytorch",
+                model_format="pt2",
+                dp_compress=True,
+                default_training_param={
+                    "model": {"descriptor": {"type": "sezm"}},
+                    "training": {},
+                },
+            )
+
+    def test_regular_pytorch_pt2_requires_dpa4_family(self):
+        with self.assertRaisesRegex(ValueError, "only exports pt2 for DPA4/SeZM"):
+            self._run(train_backend="pytorch", model_format="pt2")
 
     def test_exportable_init_frozen_model_is_rejected(self):
         with self.assertRaisesRegex(RuntimeError, "does not support"):
@@ -286,7 +326,14 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
     def test_deepmd_31_is_rejected_for_pt2(self):
         self.mdata["deepmd_version"] = "3.1.0"
         with self.assertRaisesRegex(RuntimeError, "3.2 or later"):
-            self._run(train_backend="pytorch", model_format="pt2")
+            self._run(
+                train_backend="pytorch",
+                model_format="pt2",
+                default_training_param={
+                    "model": {"descriptor": {"type": "sezm"}},
+                    "training": {},
+                },
+            )
 
     def test_finetune_keeps_source_model_suffix(self):
         train_call, _ = self._run(

--- a/tests/generator/test_deepmd_backend.py
+++ b/tests/generator/test_deepmd_backend.py
@@ -5,11 +5,13 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from dpgen.generator.lib.run_calypso import _find_models
 from dpgen.generator.run import (
     _get_checkpoint_suffix,
     _get_input_model_suffix,
     _get_model_suffix,
     _get_train_backend_flag,
+    _validate_dpa_training_config,
     _validate_pt2_template_atom_map,
     post_train_dp,
     run_md_model_devi,
@@ -77,10 +79,95 @@ class TestDeepmdBackendConfig(unittest.TestCase):
         for lines in (
             ["read_data conf.lmp\n"],
             ["read_restart restart.100\n", "atom_modify map yes\n"],
+            [
+                'if "${restart} > 0" then "read_restart restart.100" '
+                'else "read_data conf.lmp"\n',
+                "atom_modify map yes\n",
+            ],
         ):
             with self.subTest(lines=lines):
                 with self.assertRaisesRegex(ValueError, "atom_modify map yes"):
                     _validate_pt2_template_atom_map(lines)
+        with self.assertRaisesRegex(ValueError, "read_data or read_restart"):
+            _validate_pt2_template_atom_map(["atom_modify map yes\n"])
+
+    def test_dpa_backend_and_compile_option_validation(self):
+        _validate_dpa_training_config(
+            {
+                "train_backend": "pytorch",
+                "model_format": "pt2",
+                "default_training_param": {
+                    "model": {
+                        "type": "DPA4",
+                        "use_compile": True,
+                        "enable_tf32": True,
+                    },
+                    "training": {},
+                },
+            }
+        )
+        _validate_dpa_training_config(
+            {
+                "train_backend": "pt-expt",
+                "model_format": "pt2",
+                "default_training_param": {
+                    "model": {"descriptor": {"type": "DPA4C"}},
+                    "training": {
+                        "enable_compile": True,
+                        "enable_tf32": True,
+                    },
+                },
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "requires train_backend='pytorch'"):
+            _validate_dpa_training_config(
+                {
+                    "train_backend": "pytorch-exportable",
+                    "model_format": "pt2",
+                    "default_training_param": {
+                        "model": {"descriptor": {"type": "dpa4"}},
+                        "training": {},
+                    },
+                }
+            )
+        with self.assertRaisesRegex(ValueError, "training.enable_compile"):
+            _validate_dpa_training_config(
+                {
+                    "train_backend": "pytorch-exportable",
+                    "model_format": "pt2",
+                    "default_training_param": {
+                        "model": {
+                            "descriptor": {"type": "dpa4c"},
+                            "use_compile": True,
+                        },
+                        "training": {},
+                    },
+                }
+            )
+        with self.assertRaisesRegex(ValueError, "cannot mix DPA4 and DPA4C"):
+            _validate_dpa_training_config(
+                {
+                    "train_backend": "pytorch-exportable",
+                    "model_format": "pt2",
+                    "default_training_param": {
+                        "model": {
+                            "model_dict": {
+                                "dpa4": {"descriptor": {"type": "dpa4"}},
+                                "dpa4c": {"descriptor": {"type": "dpa4c"}},
+                            }
+                        },
+                        "training": {},
+                    },
+                }
+            )
+
+    def test_calypso_discovers_resolved_model_suffix(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir)
+            for name in ("graph.000.pb", "graph.000.pte", "graph.001.pte"):
+                (path / name).touch()
+            self.assertEqual(len(_find_models(path, ".pb")), 1)
+            self.assertEqual(len(_find_models(path, ".pte")), 2)
 
 
 class TestRunTrainDeepmdBackend(unittest.TestCase):
@@ -174,6 +261,16 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         )
         self.assertEqual(export_call["forward_files"], ["model.ckpt.pt"])
         self.assertIn("frozen_model_compressed.pt2", export_call["backward_files"])
+
+    def test_multiple_pt2_models_are_exported(self):
+        train_call, export_call = self._run(
+            numb_models=4,
+            train_backend="pt-expt",
+            model_format="pt2",
+        )
+        expected_tasks = [f"{index:03d}" for index in range(4)]
+        self.assertEqual(train_call["run_tasks"], expected_tasks)
+        self.assertEqual(export_call["run_tasks"], expected_tasks)
 
     def test_regular_pytorch_pt2_compression_is_rejected(self):
         with self.assertRaisesRegex(RuntimeError, "cannot compress pt2"):

--- a/tests/generator/test_deepmd_backend.py
+++ b/tests/generator/test_deepmd_backend.py
@@ -206,7 +206,7 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         }
         mdata = {
             "api_version": "1.0",
-            "model_devi_command": "lmp -k on g 1 -sf kk",
+            "model_devi_command": "lmp",
             "model_devi_group_size": 1,
             "model_devi_machine": {},
             "model_devi_resources": {},
@@ -215,7 +215,6 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
             run_md_model_devi(0, jdata, mdata)
         call = make_submission.call_args.kwargs
         self.assertEqual(call["forward_common_files"], ["graph.000.pt2"])
-        self.assertIn("lmp -k on g 1 -sf kk", call["commands"][0])
 
 
 if __name__ == "__main__":

--- a/tests/generator/test_deepmd_backend.py
+++ b/tests/generator/test_deepmd_backend.py
@@ -8,9 +8,9 @@ from unittest.mock import patch
 from dpgen.generator.run import (
     _get_checkpoint_suffix,
     _get_input_model_suffix,
-    _get_model_backend_flag,
     _get_model_suffix,
     _get_train_backend_flag,
+    _validate_pt2_template_atom_map,
     post_train_dp,
     run_md_model_devi,
     run_train_dp,
@@ -34,7 +34,7 @@ class TestDeepmdBackendConfig(unittest.TestCase):
         for backend in ("pytorch-exportable", "pt-expt"):
             with self.subTest(backend=backend):
                 jdata = {"train_backend": backend}
-                self.assertEqual(_get_model_suffix(jdata), ".pte")
+                self.assertEqual(_get_model_suffix(jdata), ".pt2")
                 self.assertEqual(_get_checkpoint_suffix(jdata), ".pt")
                 self.assertEqual(_get_train_backend_flag(jdata), "--pt-expt")
 
@@ -43,34 +43,23 @@ class TestDeepmdBackendConfig(unittest.TestCase):
             {"train_backend": "pytorch", "model_format": "pt2"},
             {"train_backend": "pytorch-exportable", "model_format": "pt2"},
             {"train_backend": "pt-expt", "model_format": "pt2"},
-            {
-                "train_backend": "pytorch",
-                "model_devi_backend": "pytorch-exportable",
-                "model_format": "pt2",
-            },
         ]
         for jdata in cases:
             with self.subTest(jdata=jdata):
                 self.assertEqual(_get_model_suffix(jdata), ".pt2")
                 self.assertEqual(_get_checkpoint_suffix(jdata), ".pt")
 
-    def test_pytorch_checkpoint_can_use_exportable_deployment(self):
-        jdata = {
-            "train_backend": "pytorch",
-            "model_devi_backend": "pt-expt",
-            "model_format": "pt2",
-        }
-        self.assertEqual(_get_train_backend_flag(jdata), "--pt")
-        self.assertEqual(_get_model_backend_flag(jdata), "--pt-expt")
-
-    def test_rejects_other_cross_backend_exports(self):
-        with self.assertRaisesRegex(ValueError, "Cannot export models"):
+    def test_pte_is_rejected_for_lammps(self):
+        with self.assertRaisesRegex(ValueError, "not supported by LAMMPS"):
             _get_model_suffix(
-                {
-                    "train_backend": "tensorflow",
-                    "model_devi_backend": "pytorch-exportable",
-                }
+                {"train_backend": "pytorch-exportable", "model_format": "pte"}
             )
+        self.assertEqual(
+            _get_model_suffix(
+                {"train_backend": "pt-expt", "model_devi_engine": "calypso"}
+            ),
+            ".pte",
+        )
 
     def test_rejects_incompatible_model_format(self):
         with self.assertRaisesRegex(ValueError, "not available for backend"):
@@ -80,6 +69,18 @@ class TestDeepmdBackendConfig(unittest.TestCase):
         self.assertEqual(_get_input_model_suffix(["a.pt", "b.pt"]), ".pt")
         with self.assertRaisesRegex(ValueError, "same non-empty file suffix"):
             _get_input_model_suffix(["a.pte", "b.pt2"])
+
+    def test_pt2_template_requires_atom_map_before_read(self):
+        _validate_pt2_template_atom_map(
+            ["atom_modify map yes\n", "read_data conf.lmp\n"]
+        )
+        for lines in (
+            ["read_data conf.lmp\n"],
+            ["read_restart restart.100\n", "atom_modify map yes\n"],
+        ):
+            with self.subTest(lines=lines):
+                with self.assertRaisesRegex(ValueError, "atom_modify map yes"):
+                    _validate_pt2_template_atom_map(lines)
 
 
 class TestRunTrainDeepmdBackend(unittest.TestCase):
@@ -93,8 +94,10 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
             "api_version": "1.0",
             "deepmd_version": "3.2.0",
             "train_command": "dp",
-            "train_machine": {},
-            "train_resources": {},
+            "train_machine": {"name": "train"},
+            "train_resources": {"queue": "train"},
+            "model_devi_machine": {"name": "model-devi"},
+            "model_devi_resources": {"queue": "model-devi"},
         }
 
     def _run(self, **updates):
@@ -102,7 +105,12 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         jdata.update(updates)
         with patch("dpgen.generator.run.make_submission") as make_submission:
             run_train_dp(0, jdata, self.mdata)
-        return make_submission.call_args.kwargs
+        calls = []
+        for call in make_submission.call_args_list:
+            details = dict(call.kwargs)
+            details["machine"], details["resources"] = call.args[:2]
+            calls.append(details)
+        return calls[0] if len(calls) == 1 else calls
 
     def test_legacy_tensorflow_commands_are_preserved(self):
         call = self._run()
@@ -111,20 +119,24 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         self.assertIn("frozen_model.pb", call["backward_files"])
         self.assertIn("model.ckpt.index", call["backward_files"])
 
-    def test_pytorch_dpa4_uses_exportable_pt2_deployment(self):
-        call = self._run(
+    def test_pytorch_dpa4_exports_pt2_on_model_devi_resources(self):
+        train_call, export_call = self._run(
             train_backend="pytorch",
-            model_devi_backend="pytorch-exportable",
             model_format="pt2",
         )
-        self.assertIn("dp --pt train", call["commands"][0])
-        self.assertIn("model.ckpt.pt", call["commands"][0])
+        self.assertEqual(train_call["machine"], self.mdata["train_machine"])
+        self.assertEqual(len(train_call["commands"]), 1)
+        self.assertIn("dp --pt train", train_call["commands"][0])
+        self.assertIn("model.ckpt.pt", train_call["backward_files"])
+        self.assertNotIn("frozen_model.pt2", train_call["backward_files"])
+        self.assertEqual(export_call["machine"], self.mdata["model_devi_machine"])
+        self.assertEqual(export_call["resources"], self.mdata["model_devi_resources"])
         self.assertEqual(
-            call["commands"][1],
-            "dp --pt-expt freeze -o frozen_model.pt2 --lower-kind graph",
+            export_call["commands"],
+            ["dp --pt freeze -c model.ckpt.pt -o frozen_model"],
         )
-        self.assertIn("frozen_model.pt2", call["backward_files"])
-        self.assertIn("model.ckpt.pt", call["backward_files"])
+        self.assertEqual(export_call["forward_files"], ["model.ckpt.pt"])
+        self.assertIn("frozen_model.pt2", export_call["backward_files"])
 
     def test_legacy_pytorch_commands_are_preserved(self):
         call = self._run(train_backend="pytorch")
@@ -135,7 +147,9 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         self.assertIn("model.ckpt.pt", call["backward_files"])
 
     def test_pytorch_exportable_dense_pte(self):
-        call = self._run(train_backend="pytorch-exportable")
+        call = self._run(
+            train_backend="pytorch-exportable", model_devi_engine="calypso"
+        )
         self.assertIn("dp --pt-expt train", call["commands"][0])
         self.assertEqual(
             call["commands"][1],
@@ -144,16 +158,22 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         self.assertIn("frozen_model.pte", call["backward_files"])
 
     def test_pytorch_exportable_dpa4c_pt2_compression(self):
-        call = self._run(train_backend="pt-expt", model_format="pt2", dp_compress=True)
-        self.assertEqual(
-            call["commands"][1],
-            "dp --pt-expt freeze -o frozen_model.pt2 --lower-kind graph",
+        train_call, export_call = self._run(
+            train_backend="pt-expt",
+            model_format="pt2",
+            dp_compress=True,
         )
+        self.assertIn("dp --pt-expt train", train_call["commands"][0])
+        self.assertEqual(len(train_call["commands"]), 1)
         self.assertEqual(
-            call["commands"][2],
-            "dp --pt-expt compress -i frozen_model.pt2 -o frozen_model_compressed.pt2",
+            export_call["commands"],
+            [
+                "dp --pt-expt freeze -c model.ckpt.pt -o frozen_model --lower-kind graph",
+                "dp --pt-expt compress -i frozen_model.pt2 -o frozen_model_compressed.pt2",
+            ],
         )
-        self.assertIn("frozen_model_compressed.pt2", call["backward_files"])
+        self.assertEqual(export_call["forward_files"], ["model.ckpt.pt"])
+        self.assertIn("frozen_model_compressed.pt2", export_call["backward_files"])
 
     def test_regular_pytorch_pt2_compression_is_rejected(self):
         with self.assertRaisesRegex(RuntimeError, "cannot compress pt2"):
@@ -172,13 +192,13 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
             self._run(train_backend="pytorch", model_format="pt2")
 
     def test_finetune_keeps_source_model_suffix(self):
-        call = self._run(
+        train_call, _ = self._run(
             train_backend="pt-expt",
             model_format="pt2",
             training_finetune_model=["source.pt"],
         )
-        self.assertIn("--finetune old/init.pt", call["commands"][0])
-        self.assertIn(str(Path("old") / "init.pt"), call["forward_files"])
+        self.assertIn("--finetune old/init.pt", train_call["commands"][0])
+        self.assertIn(str(Path("old") / "init.pt"), train_call["forward_files"])
 
     def test_post_train_links_pt2_model(self):
         jdata = {
@@ -200,7 +220,6 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         (work_path / "cur_job.json").write_text(json.dumps({}), encoding="utf-8")
         jdata = {
             "train_backend": "pytorch",
-            "model_devi_backend": "pytorch-exportable",
             "model_format": "pt2",
             "model_devi_jobs": [{}],
         }

--- a/tests/generator/test_deepmd_backend.py
+++ b/tests/generator/test_deepmd_backend.py
@@ -108,6 +108,13 @@ class TestDeepmdBackendConfig(unittest.TestCase):
         )
         _validate_dpa_training_config(
             {
+                "train_backend": "pytorch",
+                "model_format": "pt2",
+                "default_training_param": {"model": {"type": "SeZM"}},
+            }
+        )
+        _validate_dpa_training_config(
+            {
                 "train_backend": "pt-expt",
                 "model_format": "pt2",
                 "default_training_param": {
@@ -160,6 +167,10 @@ class TestDeepmdBackendConfig(unittest.TestCase):
                     },
                 }
             )
+        with self.assertRaisesRegex(ValueError, "only exports pt2 for DPA4/SeZM"):
+            _validate_dpa_training_config(
+                {"train_backend": "pytorch", "model_format": "pt2"}
+            )
 
     def test_calypso_discovers_resolved_model_suffix(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -210,6 +221,7 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         train_call, export_call = self._run(
             train_backend="pytorch",
             model_format="pt2",
+            default_training_param={"model": {"type": "dpa4"}},
         )
         self.assertEqual(train_call["machine"], self.mdata["train_machine"])
         self.assertEqual(len(train_call["commands"]), 1)
@@ -274,7 +286,12 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
 
     def test_regular_pytorch_pt2_compression_is_rejected(self):
         with self.assertRaisesRegex(RuntimeError, "cannot compress pt2"):
-            self._run(train_backend="pytorch", model_format="pt2", dp_compress=True)
+            self._run(
+                train_backend="pytorch",
+                model_format="pt2",
+                dp_compress=True,
+                default_training_param={"model": {"type": "dpa4"}},
+            )
 
     def test_exportable_init_frozen_model_is_rejected(self):
         with self.assertRaisesRegex(RuntimeError, "does not support"):
@@ -286,7 +303,11 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
     def test_deepmd_31_is_rejected_for_pt2(self):
         self.mdata["deepmd_version"] = "3.1.0"
         with self.assertRaisesRegex(RuntimeError, "3.2 or later"):
-            self._run(train_backend="pytorch", model_format="pt2")
+            self._run(
+                train_backend="pytorch",
+                model_format="pt2",
+                default_training_param={"model": {"type": "dpa4"}},
+            )
 
     def test_finetune_keeps_source_model_suffix(self):
         train_call, _ = self._run(

--- a/tests/generator/test_deepmd_backend.py
+++ b/tests/generator/test_deepmd_backend.py
@@ -206,7 +206,7 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         }
         mdata = {
             "api_version": "1.0",
-            "model_devi_command": "lmp",
+            "model_devi_command": "lmp -k on g 1 -sf kk",
             "model_devi_group_size": 1,
             "model_devi_machine": {},
             "model_devi_resources": {},
@@ -215,6 +215,7 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
             run_md_model_devi(0, jdata, mdata)
         call = make_submission.call_args.kwargs
         self.assertEqual(call["forward_common_files"], ["graph.000.pt2"])
+        self.assertIn("lmp -k on g 1 -sf kk", call["commands"][0])
 
 
 if __name__ == "__main__":

--- a/tests/generator/test_deepmd_backend.py
+++ b/tests/generator/test_deepmd_backend.py
@@ -9,7 +9,6 @@ from dpgen.generator.lib.run_calypso import _find_models
 from dpgen.generator.run import (
     _get_checkpoint_suffix,
     _get_input_model_suffix,
-    _get_model_backend_flag,
     _get_model_suffix,
     _get_train_backend_flag,
     _validate_dpa_training_config,
@@ -40,17 +39,6 @@ class TestDeepmdBackendConfig(unittest.TestCase):
                 self.assertEqual(_get_model_suffix(jdata), ".pt2")
                 self.assertEqual(_get_checkpoint_suffix(jdata), ".pt")
                 self.assertEqual(_get_train_backend_flag(jdata), "--pt-expt")
-
-    def test_model_deviation_backend_is_independent(self):
-        jdata = {
-            "train_backend": "pytorch",
-            "model_devi_backend": "pytorch-exportable",
-            "model_format": "pt2",
-        }
-        self.assertEqual(_get_checkpoint_suffix(jdata), ".pt")
-        self.assertEqual(_get_train_backend_flag(jdata), "--pt")
-        self.assertEqual(_get_model_backend_flag(jdata), "--pt-expt")
-        self.assertEqual(_get_model_suffix(jdata), ".pt2")
 
     def test_explicit_pt2_formats(self):
         cases = [
@@ -222,10 +210,6 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         train_call, export_call = self._run(
             train_backend="pytorch",
             model_format="pt2",
-            default_training_param={
-                "model": {"descriptor": {"type": "sezm"}},
-                "training": {},
-            },
         )
         self.assertEqual(train_call["machine"], self.mdata["train_machine"])
         self.assertEqual(len(train_call["commands"]), 1)
@@ -240,18 +224,6 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         )
         self.assertEqual(export_call["forward_files"], ["model.ckpt.pt"])
         self.assertIn("frozen_model.pt2", export_call["backward_files"])
-
-    def test_separate_model_backend_controls_export_command(self):
-        train_call, export_call = self._run(
-            train_backend="pytorch",
-            model_devi_backend="pytorch-exportable",
-            model_format="pt2",
-        )
-        self.assertIn("dp --pt train", train_call["commands"][0])
-        self.assertEqual(
-            export_call["commands"],
-            ["dp --pt-expt freeze -c model.ckpt.pt -o frozen_model --lower-kind graph"],
-        )
 
     def test_legacy_pytorch_commands_are_preserved(self):
         call = self._run(train_backend="pytorch")
@@ -302,19 +274,7 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
 
     def test_regular_pytorch_pt2_compression_is_rejected(self):
         with self.assertRaisesRegex(RuntimeError, "cannot compress pt2"):
-            self._run(
-                train_backend="pytorch",
-                model_format="pt2",
-                dp_compress=True,
-                default_training_param={
-                    "model": {"descriptor": {"type": "sezm"}},
-                    "training": {},
-                },
-            )
-
-    def test_regular_pytorch_pt2_requires_dpa4_family(self):
-        with self.assertRaisesRegex(ValueError, "only exports pt2 for DPA4/SeZM"):
-            self._run(train_backend="pytorch", model_format="pt2")
+            self._run(train_backend="pytorch", model_format="pt2", dp_compress=True)
 
     def test_exportable_init_frozen_model_is_rejected(self):
         with self.assertRaisesRegex(RuntimeError, "does not support"):
@@ -326,14 +286,7 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
     def test_deepmd_31_is_rejected_for_pt2(self):
         self.mdata["deepmd_version"] = "3.1.0"
         with self.assertRaisesRegex(RuntimeError, "3.2 or later"):
-            self._run(
-                train_backend="pytorch",
-                model_format="pt2",
-                default_training_param={
-                    "model": {"descriptor": {"type": "sezm"}},
-                    "training": {},
-                },
-            )
+            self._run(train_backend="pytorch", model_format="pt2")
 
     def test_finetune_keeps_source_model_suffix(self):
         train_call, _ = self._run(

--- a/tests/generator/test_deepmd_backend.py
+++ b/tests/generator/test_deepmd_backend.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 import unittest
@@ -7,9 +8,11 @@ from unittest.mock import patch
 from dpgen.generator.run import (
     _get_checkpoint_suffix,
     _get_input_model_suffix,
+    _get_model_backend_flag,
     _get_model_suffix,
     _get_train_backend_flag,
     post_train_dp,
+    run_md_model_devi,
     run_train_dp,
 )
 
@@ -36,11 +39,38 @@ class TestDeepmdBackendConfig(unittest.TestCase):
                 self.assertEqual(_get_train_backend_flag(jdata), "--pt-expt")
 
     def test_explicit_pt2_formats(self):
-        for backend in ("pytorch", "pytorch-exportable", "pt-expt"):
-            with self.subTest(backend=backend):
-                jdata = {"train_backend": backend, "model_format": "pt2"}
+        cases = [
+            {"train_backend": "pytorch", "model_format": "pt2"},
+            {"train_backend": "pytorch-exportable", "model_format": "pt2"},
+            {"train_backend": "pt-expt", "model_format": "pt2"},
+            {
+                "train_backend": "pytorch",
+                "model_devi_backend": "pytorch-exportable",
+                "model_format": "pt2",
+            },
+        ]
+        for jdata in cases:
+            with self.subTest(jdata=jdata):
                 self.assertEqual(_get_model_suffix(jdata), ".pt2")
                 self.assertEqual(_get_checkpoint_suffix(jdata), ".pt")
+
+    def test_pytorch_checkpoint_can_use_exportable_deployment(self):
+        jdata = {
+            "train_backend": "pytorch",
+            "model_devi_backend": "pt-expt",
+            "model_format": "pt2",
+        }
+        self.assertEqual(_get_train_backend_flag(jdata), "--pt")
+        self.assertEqual(_get_model_backend_flag(jdata), "--pt-expt")
+
+    def test_rejects_other_cross_backend_exports(self):
+        with self.assertRaisesRegex(ValueError, "Cannot export models"):
+            _get_model_suffix(
+                {
+                    "train_backend": "tensorflow",
+                    "model_devi_backend": "pytorch-exportable",
+                }
+            )
 
     def test_rejects_incompatible_model_format(self):
         with self.assertRaisesRegex(ValueError, "not available for backend"):
@@ -81,11 +111,18 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         self.assertIn("frozen_model.pb", call["backward_files"])
         self.assertIn("model.ckpt.index", call["backward_files"])
 
-    def test_regular_pytorch_dpa4_pt2(self):
-        call = self._run(train_backend="pytorch", model_format="pt2")
+    def test_pytorch_dpa4_uses_exportable_pt2_deployment(self):
+        call = self._run(
+            train_backend="pytorch",
+            model_devi_backend="pytorch-exportable",
+            model_format="pt2",
+        )
         self.assertIn("dp --pt train", call["commands"][0])
         self.assertIn("model.ckpt.pt", call["commands"][0])
-        self.assertEqual(call["commands"][1], "dp --pt freeze -o frozen_model.pt2")
+        self.assertEqual(
+            call["commands"][1],
+            "dp --pt-expt freeze -o frozen_model.pt2 --lower-kind graph",
+        )
         self.assertIn("frozen_model.pt2", call["backward_files"])
         self.assertIn("model.ckpt.pt", call["backward_files"])
 
@@ -155,6 +192,30 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
             str(Path("000") / "frozen_model.pt2"),
             str(Path("iter.000000") / "00.train" / "graph.000.pt2"),
         )
+
+    def test_model_deviation_forwards_pt2_models(self):
+        work_path = Path("iter.000000") / "01.model_devi"
+        (work_path / "task.000.000000").mkdir(parents=True)
+        (work_path / "graph.000.pt2").touch()
+        (work_path / "cur_job.json").write_text(json.dumps({}), encoding="utf-8")
+        jdata = {
+            "train_backend": "pytorch",
+            "model_devi_backend": "pytorch-exportable",
+            "model_format": "pt2",
+            "model_devi_jobs": [{}],
+        }
+        mdata = {
+            "api_version": "1.0",
+            "model_devi_command": "lmp -k on g 1 -sf kk",
+            "model_devi_group_size": 1,
+            "model_devi_machine": {},
+            "model_devi_resources": {},
+        }
+        with patch("dpgen.generator.run.make_submission") as make_submission:
+            run_md_model_devi(0, jdata, mdata)
+        call = make_submission.call_args.kwargs
+        self.assertEqual(call["forward_common_files"], ["graph.000.pt2"])
+        self.assertIn("lmp -k on g 1 -sf kk", call["commands"][0])
 
 
 if __name__ == "__main__":

--- a/tests/generator/test_deepmd_backend.py
+++ b/tests/generator/test_deepmd_backend.py
@@ -5,7 +5,10 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from dpgen.generator.lib.run_calypso import _find_models
+from dpgen.generator.lib.run_calypso import (
+    _find_models,
+    _make_calypso_opt_command,
+)
 from dpgen.generator.run import (
     _get_checkpoint_suffix,
     _get_input_model_suffix,
@@ -179,6 +182,10 @@ class TestDeepmdBackendConfig(unittest.TestCase):
                 (path / name).touch()
             self.assertEqual(len(_find_models(path, ".pb")), 1)
             self.assertEqual(len(_find_models(path, ".pte")), 2)
+
+    def test_calypso_optimizer_uses_resolved_model(self):
+        command = _make_calypso_opt_command("python", "graph.000.pt2")
+        self.assertIn("calypso_run_opt.py --model ../graph.000.pt2", command)
 
 
 class TestRunTrainDeepmdBackend(unittest.TestCase):

--- a/tests/generator/test_deepmd_backend.py
+++ b/tests/generator/test_deepmd_backend.py
@@ -5,12 +5,15 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from dpgen.generator.arginfo import run_mdata_arginfo
 from dpgen.generator.lib.run_calypso import (
     _find_models,
+    _make_calypso_check_command,
     _make_calypso_opt_command,
 )
 from dpgen.generator.run import (
     _get_checkpoint_suffix,
+    _get_export_command,
     _get_input_model_suffix,
     _get_model_suffix,
     _get_train_backend_flag,
@@ -79,6 +82,11 @@ class TestDeepmdBackendConfig(unittest.TestCase):
         _validate_pt2_template_atom_map(
             ["atom_modify map yes\n", "read_data conf.lmp\n"]
         )
+        for atom_map in ("array", "hash"):
+            with self.subTest(atom_map=atom_map):
+                _validate_pt2_template_atom_map(
+                    [f"atom_modify map {atom_map}\n", "read_data conf.lmp\n"]
+                )
         for lines in (
             ["read_data conf.lmp\n"],
             ["read_restart restart.100\n", "atom_modify map yes\n"],
@@ -89,7 +97,7 @@ class TestDeepmdBackendConfig(unittest.TestCase):
             ],
         ):
             with self.subTest(lines=lines):
-                with self.assertRaisesRegex(ValueError, "atom_modify map yes"):
+                with self.assertRaisesRegex(ValueError, "atom_modify map"):
                     _validate_pt2_template_atom_map(lines)
         with self.assertRaisesRegex(ValueError, "read_data or read_restart"):
             _validate_pt2_template_atom_map(["atom_modify map yes\n"])
@@ -187,6 +195,23 @@ class TestDeepmdBackendConfig(unittest.TestCase):
         command = _make_calypso_opt_command("python", "graph.000.pt2")
         self.assertIn("calypso_run_opt.py --model ../graph.000.pt2", command)
 
+    def test_calypso_recovery_uses_resolved_model(self):
+        command = _make_calypso_check_command("python", "graph.000.pt2")
+        self.assertEqual(command, "python check_outcar.py --model ../graph.000.pt2")
+
+    def test_export_command_uses_deployment_executable(self):
+        self.assertEqual(
+            _get_export_command(
+                {"train_command": "/train/dp", "train_export_command": "/deploy/dp"},
+                "--pt",
+            ),
+            "/deploy/dp --pt",
+        )
+
+    def test_export_command_is_accepted_in_machine_configuration(self):
+        train = run_mdata_arginfo().sub_fields["train"]
+        self.assertIn("export_command", train.sub_fields)
+
 
 class TestRunTrainDeepmdBackend(unittest.TestCase):
     def setUp(self):
@@ -243,6 +268,41 @@ class TestRunTrainDeepmdBackend(unittest.TestCase):
         )
         self.assertEqual(export_call["forward_files"], ["model.ckpt.pt"])
         self.assertIn("frozen_model.pt2", export_call["backward_files"])
+
+    def test_pt2_export_uses_deployment_command(self):
+        self.mdata["train_command"] = "/train/dp"
+        self.mdata["train_export_command"] = "/deploy/dp"
+        _, export_call = self._run(
+            train_backend="pytorch",
+            model_format="pt2",
+            default_training_param={"model": {"type": "dpa4"}},
+        )
+        self.assertEqual(
+            export_call["commands"],
+            ["/deploy/dp --pt freeze -c model.ckpt.pt -o frozen_model"],
+        )
+
+    def test_pt2_export_reuses_completed_training_checkpoints(self):
+        task = Path("iter.000000") / "00.train" / "000"
+        task.mkdir(parents=True)
+        (task / "model.ckpt.pt").touch()
+        with patch("dpgen.generator.run.make_submission") as make_submission:
+            run_train_dp(
+                0,
+                {
+                    "numb_models": 1,
+                    "one_h5": True,
+                    "train_backend": "pytorch",
+                    "model_format": "pt2",
+                    "default_training_param": {"model": {"type": "dpa4"}},
+                },
+                self.mdata,
+            )
+        self.assertEqual(make_submission.call_count, 1)
+        self.assertEqual(
+            make_submission.call_args.kwargs["commands"],
+            ["dp --pt freeze -c model.ckpt.pt -o frozen_model"],
+        )
 
     def test_legacy_pytorch_commands_are_preserved(self):
         call = self._run(train_backend="pytorch")

--- a/tests/generator/test_lammps.py
+++ b/tests/generator/test_lammps.py
@@ -96,6 +96,25 @@ class TestMakeLammpsInput(unittest.TestCase):
         )
         self.assertEqual(pimd_result.count(atom_map), 1)
 
+    def test_pt2_uses_explicit_type_mapping(self):
+        """Test that DP-GEN's LAMMPS type order is passed to DeepMD."""
+        result = make_lammps_input(
+            self.ensemble,
+            self.conf_file,
+            self.graphs,
+            self.nsteps,
+            self.dt,
+            self.neidelay,
+            self.trj_freq,
+            self.mass_map,
+            self.temp,
+            {"model_format": "pt2", "type_map": ["C", "Cl", "H", "O"]},
+            pres=1.0,
+            deepmd_version=self.deepmd_version,
+        )
+
+        self.assertIn("pair_coeff      * * C Cl H O\n", result)
+
     def test_d3_enabled_basic(self):
         """Test LAMMPS input with D3 dispersion enabled."""
         jdata = {
@@ -105,7 +124,8 @@ class TestMakeLammpsInput(unittest.TestCase):
                 "functional": "pbe",
                 "cutoff": 30.0,
                 "cn_cutoff": 20.0,
-            }
+            },
+            "type_map": ["H", "O"],
         }
 
         result = make_lammps_input(
@@ -126,6 +146,9 @@ class TestMakeLammpsInput(unittest.TestCase):
         # Should contain hybrid/overlay pair_style
         self.assertIn("pair_style      hybrid/overlay deepmd model.pb", result)
         self.assertIn("dispersion/d3 original pbe 30.0 20.0", result)
+
+        self.assertIn("pair_coeff      * * deepmd H O\n", result)
+        self.assertIn("pair_coeff      * * dispersion/d3 H O\n", result)
 
         # Should contain both pair_coeff lines
         lines = result.split("\n")

--- a/tests/generator/test_lammps.py
+++ b/tests/generator/test_lammps.py
@@ -55,6 +55,46 @@ class TestMakeLammpsInput(unittest.TestCase):
         # Should NOT contain hybrid/overlay or dispersion/d3
         self.assertNotIn("hybrid/overlay", result)
         self.assertNotIn("dispersion/d3", result)
+        self.assertNotIn("atom_modify        map yes", result)
+
+    def test_pt2_enables_atom_map_before_read(self):
+        """Test that pt2 models enable one atom map before defining the box."""
+        result = make_lammps_input(
+            self.ensemble,
+            self.conf_file,
+            self.graphs,
+            self.nsteps,
+            self.dt,
+            self.neidelay,
+            self.trj_freq,
+            self.mass_map,
+            self.temp,
+            {"model_format": "pt2"},
+            pres=1.0,
+            deepmd_version=self.deepmd_version,
+        )
+
+        atom_map = "atom_modify        map yes"
+        self.assertEqual(result.count(atom_map), 1)
+        self.assertLess(result.index(atom_map), result.index("read_restart"))
+        self.assertLess(result.index(atom_map), result.index("read_data"))
+
+        pimd_result = make_lammps_input(
+            self.ensemble,
+            self.conf_file,
+            self.graphs,
+            self.nsteps,
+            self.dt,
+            self.neidelay,
+            self.trj_freq,
+            self.mass_map,
+            self.temp,
+            {"model_format": "pt2"},
+            pres=1.0,
+            deepmd_version=self.deepmd_version,
+            nbeads=4,
+        )
+        self.assertEqual(pimd_result.count(atom_map), 1)
 
     def test_d3_enabled_basic(self):
         """Test LAMMPS input with D3 dispersion enabled."""

--- a/tests/generator/test_make_md.py
+++ b/tests/generator/test_make_md.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import sys
 import unittest
+from unittest.mock import patch
 
 import dpdata
 import numpy as np
@@ -514,6 +515,68 @@ class TestMakeModelDeviRevMat(unittest.TestCase):
                         " ".join(ii.split()),
                     )
         os.chdir(cwd_)
+
+    def test_pt2_template_with_atom_map(self):
+        test_dir = os.path.dirname(__file__)
+        with open(os.path.join(test_dir, "lmp", "input.lammps")) as fp:
+            template = fp.read()
+        template = template.replace(
+            "read_data       conf.lmp",
+            "atom_modify     map yes\nread_data       conf.lmp",
+        )
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".lammps", dir=".", delete=False
+        ) as fp:
+            fp.write(template)
+            template_path = os.path.abspath(fp.name)
+        self.addCleanup(os.remove, template_path)
+
+        jdata = {
+            "type_map": ["Mg", "Al"],
+            "mass_map": [24, 27],
+            "init_data_prefix": "data",
+            "init_data_sys": ["deepmd"],
+            "init_batch_size": [16],
+            "sys_configs_prefix": test_dir,
+            "sys_configs": [
+                ["data/al.fcc.02x02x02/01.scale_pert/sys-0032/scale*/000001/POSCAR"]
+            ],
+            "numb_models": 1,
+            "shuffle_poscar": False,
+            "model_devi_f_trust_lo": 0.050,
+            "model_devi_f_trust_hi": 0.150,
+            "train_backend": "pytorch",
+            "model_format": "pt2",
+            "model_devi_jobs": [
+                {
+                    "sys_idx": [0],
+                    "traj_freq": 10,
+                    "template": {"lmp": template_path},
+                }
+            ],
+        }
+        train_path = os.path.join("iter.000000", "00.train")
+        os.makedirs(train_path, exist_ok=True)
+        with open(os.path.join(train_path, "graph.000.pt2"), "w") as fp:
+            fp.write("model")
+
+        def copy_link(source, target):
+            if not os.path.isabs(source):
+                source = os.path.join(os.path.dirname(target), source)
+            shutil.copyfile(os.path.normpath(source), target)
+
+        with patch("dpgen.generator.run.os.symlink", side_effect=copy_link):
+            make_model_devi(0, jdata, {"deepmd_version": "3.2"})
+        task = sorted(glob.glob("iter.000000/01.model_devi/task.*"))[0]
+        with open(os.path.join(task, "input.lammps")) as fp:
+            lines = fp.readlines()
+        atom_map_index = next(
+            index for index, line in enumerate(lines) if "atom_modify" in line
+        )
+        read_data_index = next(
+            index for index, line in enumerate(lines) if "read_data" in line
+        )
+        self.assertLess(atom_map_index, read_data_index)
 
 
 class TestParseCurJobRevMat(unittest.TestCase):

--- a/tests/generator/test_make_md.py
+++ b/tests/generator/test_make_md.py
@@ -11,7 +11,11 @@ from unittest.mock import patch
 import dpdata
 import numpy as np
 
-from dpgen.generator.run import _read_model_devi_file, parse_cur_job_sys_revmat
+from dpgen.generator.run import (
+    _read_model_devi_file,
+    parse_cur_job_sys_revmat,
+    revise_lmp_input_pair_coeff,
+)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 __package__ = "generator"
@@ -203,6 +207,7 @@ class TestMakeModelDevi(unittest.TestCase):
             lammps_input.index("atom_modify        map yes"),
             lammps_input.index("read_data"),
         )
+        self.assertIn("pair_coeff      * * Mg Al\n", lammps_input)
 
     def test_make_model_devi_pimd(self):
         if os.path.isdir("iter.000000"):
@@ -683,6 +688,51 @@ class TestParseCurJobSysRevMat(unittest.TestCase):
 
 
 class MakeModelDeviByReviseMatrix(unittest.TestCase):
+    def test_revise_lmp_input_pair_coeff_adds_type_map(self):
+        jdata = {"type_map": ["C", "Cl", "H", "O"]}
+        cases = (
+            ("pair_coeff\n", "pair_coeff      * * C Cl H O\n"),
+            ("pair_coeff * *\n", "pair_coeff      * * C Cl H O\n"),
+            (
+                "pair_coeff * * deepmd\n",
+                "pair_coeff      * * deepmd C Cl H O\n",
+            ),
+        )
+
+        for pair_coeff, expected in cases:
+            with self.subTest(pair_coeff=pair_coeff):
+                lines = ["pair_style deepmd graph.pb\n", pair_coeff]
+                result = revise_lmp_input_pair_coeff(lines, jdata)
+                self.assertEqual(result[1], expected)
+
+    def test_revise_lmp_input_pair_coeff_preserves_explicit_mapping(self):
+        jdata = {"type_map": ["C", "Cl", "H", "O"]}
+        cases = (
+            "pair_coeff * * H O\n",
+            "pair_coeff * * deepmd H O\n",
+        )
+
+        for pair_coeff in cases:
+            with self.subTest(pair_coeff=pair_coeff):
+                lines = ["pair_style deepmd graph.pb\n", pair_coeff]
+                result = revise_lmp_input_pair_coeff(lines, jdata)
+                self.assertEqual(result[1], pair_coeff)
+
+    def test_revise_lmp_input_pair_coeff_d3_is_idempotent(self):
+        jdata = {
+            "type_map": ["C", "Cl", "H", "O"],
+            "lmp_d3": {"enable": True},
+        }
+        lines = ["pair_style deepmd graph.pb\n", "pair_coeff * *\n"]
+
+        result = revise_lmp_input_pair_coeff(lines, jdata)
+        result = revise_lmp_input_pair_coeff(result, jdata)
+
+        self.assertEqual(result.count("pair_coeff      * * deepmd C Cl H O\n"), 1)
+        self.assertEqual(
+            result.count("pair_coeff      * * dispersion/d3 C Cl H O\n"), 1
+        )
+
     def test_find_only_one_key_1(self):
         lines = ["aaa bbb ccc\n", "bbb ccc\n", "ccc bbb ccc\n"]
         idx = find_only_one_key(lines, ["bbb", "ccc"])

--- a/tests/generator/test_make_md.py
+++ b/tests/generator/test_make_md.py
@@ -516,7 +516,7 @@ class TestMakeModelDeviRevMat(unittest.TestCase):
                     )
         os.chdir(cwd_)
 
-    def test_pt2_template_with_atom_map(self):
+    def test_default_pt2_template_with_atom_map(self):
         test_dir = os.path.dirname(__file__)
         with open(os.path.join(test_dir, "lmp", "input.lammps")) as fp:
             template = fp.read()
@@ -545,8 +545,7 @@ class TestMakeModelDeviRevMat(unittest.TestCase):
             "shuffle_poscar": False,
             "model_devi_f_trust_lo": 0.050,
             "model_devi_f_trust_hi": 0.150,
-            "train_backend": "pytorch",
-            "model_format": "pt2",
+            "train_backend": "pytorch-exportable",
             "model_devi_jobs": [
                 {
                     "sys_idx": [0],

--- a/tests/generator/test_make_md.py
+++ b/tests/generator/test_make_md.py
@@ -163,6 +163,47 @@ class TestMakeModelDevi(unittest.TestCase):
         _check_pt(self, 0, jdata)
         # shutil.rmtree('iter.000000')
 
+    def test_make_model_devi_default_pt2_atom_map(self):
+        test_dir = os.path.dirname(__file__)
+        with open(os.path.join(test_dir, param_file)) as fp:
+            jdata = json.load(fp)
+        with open(os.path.join(test_dir, machine_file)) as fp:
+            mdata = json.load(fp)
+        jdata["train_backend"] = "pytorch-exportable"
+        jdata["sys_configs_prefix"] = test_dir
+        jdata["sys_configs"] = [
+            ["data/al.fcc.02x02x02/01.scale_pert/sys-0032/scale*/000001/POSCAR"]
+        ]
+        jdata["model_devi_jobs"][0]["sys_idx"] = [0]
+        jdata["model_devi_jobs"][0]["temps"] = [50]
+        jdata["model_devi_jobs"][0]["press"] = [1.0]
+        jdata.pop("model_format", None)
+
+        train_dir = os.path.join("iter.000000", "00.train")
+        os.makedirs(train_dir, exist_ok=True)
+        for model_index in range(jdata["numb_models"]):
+            with open(
+                os.path.join(train_dir, f"graph.{model_index:03d}.pt2"), "w"
+            ) as fp:
+                fp.write("model")
+
+        def copy_link(source, target):
+            if not os.path.isabs(source):
+                source = os.path.join(os.path.dirname(target), source)
+            shutil.copyfile(os.path.normpath(source), target)
+
+        with patch("dpgen.generator.run.os.symlink", side_effect=copy_link):
+            make_model_devi(0, jdata, mdata)
+
+        task = sorted(glob.glob("iter.000000/01.model_devi/task.*"))[0]
+        with open(os.path.join(task, "input.lammps")) as fp:
+            lammps_input = fp.read()
+        self.assertEqual(lammps_input.count("atom_modify        map yes"), 1)
+        self.assertLess(
+            lammps_input.index("atom_modify        map yes"),
+            lammps_input.index("read_data"),
+        )
+
     def test_make_model_devi_pimd(self):
         if os.path.isdir("iter.000000"):
             shutil.rmtree("iter.000000")

--- a/tests/generator/test_make_md.py
+++ b/tests/generator/test_make_md.py
@@ -718,6 +718,19 @@ class MakeModelDeviByReviseMatrix(unittest.TestCase):
                 result = revise_lmp_input_pair_coeff(lines, jdata)
                 self.assertEqual(result[1], pair_coeff)
 
+    def test_revise_lmp_input_pair_coeff_selects_deepmd_in_hybrid(self):
+        jdata = {"type_map": ["C", "Cl", "H", "O"]}
+        lines = [
+            "pair_style hybrid/overlay deepmd graph.pb zero 10.0\n",
+            "pair_coeff * * zero 10.0\n",
+            "pair_coeff * * deepmd\n",
+        ]
+
+        result = revise_lmp_input_pair_coeff(lines, jdata)
+
+        self.assertEqual(result[1], "pair_coeff * * zero 10.0\n")
+        self.assertEqual(result[2], "pair_coeff      * * deepmd C Cl H O\n")
+
     def test_revise_lmp_input_pair_coeff_d3_is_idempotent(self):
         jdata = {
             "type_map": ["C", "Cl", "H", "O"],


### PR DESCRIPTION
## Summary

- add the DeePMD PyTorch-exportable training backend, with pt-expt as an alias
- support DPA4 export through dp --pt freeze to pt2
- support DPA4C training and graph export through dp --pt-expt, including optional compression
- keep training checkpoints separate from frozen model artifacts
- run target-specific pt2 export on model-deviation machine/resources
- forward all committee pt2 models and add the required LAMMPS atom-ID map before read_data/read_restart
- emit explicit DeepMD chemical-element mapping from the configured type_map in pair_coeff
- preserve the TensorFlow/pb default and existing PyTorch/JAX behavior

## Configuration

DPA4:

    "train_backend": "pytorch",
    "model_format": "pt2",
    "default_training_param": {
      "model": {"type": "dpa4"}
    }

DPA4C:

    "train_backend": "pytorch-exportable",
    "model_format": "pt2",
    "dp_compress": true,
    "default_training_param": {
      "model": {"descriptor": {"type": "dpa4c"}}
    }

Freeze and export intentionally use the same backend as training. Regular PyTorch and PyTorch-exportable checkpoints are backend-specific; this PR does not advertise cross-backend checkpoint conversion. The default train_backend remains tensorflow.

AOTInductor pt2 artifacts are exported in a separate submission using model_devi_machine and model_devi_resources so compilation occurs on the deployment target.

Fixes #1925.

## Validation

- relevant backend, LAMMPS-input, and model-deviation regression tests
- pre-commit checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added PyTorch backend support for DPA4/DPA4C training and deployment configurations.
  - Added `.pt2` export workflows with checkpoint-based freezing and compression.
  - Added automatic model format handling for model deviation and CALYPSO workflows.
  - Added configurable CALYPSO model selection.
  - Added explicit LAMMPS type-map support and required atom mapping for `.pt2` models.

- **Bug Fixes**
  - Improved validation for incompatible backends, versions, acceleration settings, and compression options.
  - Clarified limitations for unsupported cross-backend conversions and `pte` usage with LAMMPS.

- **Documentation**
  - Expanded guidance for PyTorch configurations, exports, checkpoints, and deployment constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->