### PR TITLE
fix: preserve surface POSCAR input paths

### DIFF
--- a/dpgen/data/surf.py
+++ b/dpgen/data/surf.py
@@ -229,8 +229,7 @@ def make_super_cell_pymatgen(jdata):
 
     if from_poscar:
         from_poscar_path = jdata["from_poscar_path"]
-        poscar_name = os.path.basename(from_poscar_path)
-        ss = Structure.from_file(poscar_name)
+        ss = Structure.from_file(from_poscar_path)
     else:
         from_path = path_uc
         from_file = os.path.join(from_path, "POSCAR.unit")

--- a/tests/data/test_gen_surf_poscar.py
+++ b/tests/data/test_gen_surf_poscar.py
@@ -3,6 +3,7 @@ import json
 import os
 import shutil
 import sys
+import tempfile
 import unittest
 
 from pymatgen.core import Element, Structure
@@ -34,6 +35,10 @@ class TestGenSurfPOSCAR(unittest.TestCase):
         ]
         with open(param_file) as fp:
             jdata = json.load(fp)
+        self.input_dir = tempfile.mkdtemp()
+        from_poscar_path = os.path.join(self.input_dir, "nested.POSCAR")
+        shutil.copy2("POSCAR", from_poscar_path)
+        jdata["from_poscar_path"] = from_poscar_path
         out_dir = out_dir_name(jdata)
         jdata["out_dir"] = out_dir
         self.root_dir = out_dir
@@ -47,13 +52,16 @@ class TestGenSurfPOSCAR(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.root_dir)
+        shutil.rmtree(self.input_dir)
 
     def test(self):
-        surfs = glob.glob("POSCAR.01x01x01/01.scale_pert/surf*")
+        surfs = glob.glob(os.path.join(self.root_dir, "01.scale_pert", "surf*"))
         surfs = [ii.split("/")[-1] for ii in surfs]
         surfs.sort()
         self.assertEqual(surfs, self.surfs)
-        poscars = glob.glob("POSCAR.01x01x01/00.place_ele/surf*/sys*/POSCAR")
+        poscars = glob.glob(
+            os.path.join(self.root_dir, "00.place_ele", "surf*", "sys*", "POSCAR")
+        )
         for poscar in poscars:
             surf = poscar.split("/")[-3]
             st1 = Structure.from_file(surf + ".POSCAR")
@@ -63,7 +71,14 @@ class TestGenSurfPOSCAR(unittest.TestCase):
 
         for surf in self.surfs:
             elongs = glob.glob(
-                "POSCAR.01x01x01/01.scale_pert/" + surf + "/sys-*/scale-1.000/el*"
+                os.path.join(
+                    self.root_dir,
+                    "01.scale_pert",
+                    surf,
+                    "sys-*",
+                    "scale-1.000",
+                    "el*",
+                )
             )
             elongs = [ii.split("/")[-1] for ii in elongs]
             elongs.sort()


### PR DESCRIPTION
## Summary
- Pass the complete `from_poscar_path` to pymatgen when creating surface supercells.
- Exercise the surface workflow with a POSCAR stored outside the working directory.

## Tests
- `PYTHONPATH=/home/jzzeng/codes/dpgen python -m unittest tests.data.test_gen_surf_poscar -v`
- `ruff check dpgen/data/surf.py tests/data/test_gen_surf_poscar.py`
- `ruff format --check dpgen/data/surf.py tests/data/test_gen_surf_poscar.py`

Fixes #1912

Coding agent: Codex
Codex version: codex-cli 0.149.0
Model: gpt-5.6-sol
Reasoning effort: xhigh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed structure loading to correctly use the configured input path, including files located outside the current directory.
  * Improved surface-generation output discovery for custom input locations.

* **Tests**
  * Added coverage for POSCAR files supplied from temporary and non-default directories.
  * Updated validation to use generated output locations rather than hardcoded paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->