### PR TITLE
fix: remove legacy model type map override

### DIFF
--- a/dpgen/generator/lib/calypso_run_model_devi.py
+++ b/dpgen/generator/lib/calypso_run_model_devi.py
@@ -7,8 +7,6 @@ import shutil
 
 import dpdata
 import numpy as np
-from deepmd.infer import DeepPot as DP
-from deepmd.infer import calc_model_devi
 
 
 def write_model_devi_out(devi, fname):
@@ -32,11 +30,22 @@ def write_model_devi_out(devi, fname):
     return devi
 
 
-def Modd(all_models, type_map):
+def _remap_atom_types(atom_types, type_map, model_type_map):
+    """Map DP-GEN's top-level type order to the model type order."""
+    model_type_indices = np.asarray(
+        [model_type_map.index(element) for element in type_map], dtype=int
+    )
+    return model_type_indices[np.asarray(atom_types, dtype=int)]
+
+
+def Modd(all_models, type_map, model_type_map=None):
     # Model Devi
+    from deepmd.infer import DeepPot as DP
+    from deepmd.infer import calc_model_devi
 
     cwd = os.getcwd()
     graphs = [DP(model) for model in all_models]
+    model_type_map = type_map if model_type_map is None else model_type_map
 
     Devis = []
     pcount = 0
@@ -74,7 +83,9 @@ def Modd(all_models, type_map):
                 nopbc = pdata.nopbc
                 coord = pdata.data["coords"]
                 cell = pdata.data["cells"] if not nopbc else None
-                atom_types = pdata.data["atom_types"]
+                atom_types = _remap_atom_types(
+                    pdata.data["atom_types"], type_map, model_type_map
+                )
                 try:
                     devi = calc_model_devi(coord, cell, atom_types, graphs, nopbc=nopbc)
                 except TypeError:
@@ -131,7 +142,12 @@ if __name__ == "__main__":
         nargs="+",
         help="the type map of models which will be used to do model-deviation",
     )
+    parser.add_argument(
+        "--model_type_map",
+        nargs="+",
+        help="the type map used by the model artifacts",
+    )
     args = parser.parse_args()
     # print(vars(args))
-    Modd(args.all_models, args.type_map)
+    Modd(args.all_models, args.type_map, args.model_type_map)
     # Modd(sys.argv[1],sys.argv[2])

--- a/dpgen/generator/lib/lammps.py
+++ b/dpgen/generator/lib/lammps.py
@@ -149,15 +149,15 @@ def make_lammps_input(
             else:
                 ret += f"pair_style      deepmd {graph_list} out_freq ${{THERMO_FREQ}} out_file model_devi${{ibead}}.out {keywords}\n"
 
-    # Add pair_coeff lines
+    # Map LAMMPS numeric types to their chemical species. Direct callers
+    # without a type map retain the historical bare coefficient line.
+    type_map_str = " ".join(jdata.get("type_map", []))
+    type_map_args = f" {type_map_str}" if type_map_str else ""
     if d3_enabled:
-        # D3 requires type maps (element symbols)
-        type_map = jdata.get("type_map", [])
-        type_map_str = " ".join(type_map)
-        ret += "pair_coeff      * * deepmd\n"
+        ret += f"pair_coeff      * * deepmd{type_map_args}\n"
         ret += f"pair_coeff      * * dispersion/d3 {type_map_str}\n"
     else:
-        ret += "pair_coeff      * *\n"
+        ret += f"pair_coeff      * *{type_map_args}\n"
     ret += "\n"
     ret += "thermo_style    custom step temp pe ke etotal press vol lx ly lz xy xz yz\n"
     ret += "thermo          ${THERMO_FREQ}\n"

--- a/dpgen/generator/lib/run_calypso.py
+++ b/dpgen/generator/lib/run_calypso.py
@@ -493,6 +493,11 @@ def run_calypso_model_devi(iter_index, jdata, mdata):
             # Model Devi
             _calypso_run_opt_path = os.path.abspath(caly_run_opt_list[0])
             all_models = glob.glob(os.path.join(_calypso_run_opt_path, "graph*pb"))
+            model_type_map = (
+                jdata.get("default_training_param", {})
+                .get("model", {})
+                .get("type_map", jdata["type_map"])
+            )
             cwd = os.getcwd()
             os.chdir(calypso_model_devi_path)
             args = " ".join(
@@ -502,6 +507,8 @@ def run_calypso_model_devi(iter_index, jdata, mdata):
                     " ".join(all_models),
                     "--type_map",
                     " ".join(jdata.get("type_map")),
+                    "--model_type_map",
+                    " ".join(model_type_map),
                 ]
             )
             deepmdkit_python = mdata.get("model_devi_deepmdkit_python")

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -460,7 +460,6 @@ def make_train_dp(iter_index, jdata, mdata):
         # 1.x
         jinput["training"]["systems"] = init_data_sys
         jinput["training"]["batch_size"] = init_batch_size
-        jinput["model"]["type_map"] = jdata["type_map"]
         # electron temperature
         if use_ele_temp == 0:
             pass
@@ -483,7 +482,6 @@ def make_train_dp(iter_index, jdata, mdata):
             isinstance(old_batch_size, str) and old_batch_size.startswith("mixed:")
         ):
             jinput["training"]["training_data"]["batch_size"] = init_batch_size
-        jinput["model"]["type_map"] = jdata["type_map"]
         # electron temperature
         if use_ele_temp == 0:
             pass

--- a/dpgen/generator/run.py
+++ b/dpgen/generator/run.py
@@ -482,6 +482,13 @@ def make_train_dp(iter_index, jdata, mdata):
             isinstance(old_batch_size, str) and old_batch_size.startswith("mixed:")
         ):
             jinput["training"]["training_data"]["batch_size"] = init_batch_size
+        if (
+            Version(mdata["deepmd_version"]) >= Version("3")
+            and jdata.get("train_backend") == "pytorch"
+        ):
+            # DeePMD-kit PyTorch requires model.type_map, but preserve an
+            # explicitly configured model order.
+            jinput["model"].setdefault("type_map", jdata["type_map"])
         # electron temperature
         if use_ele_temp == 0:
             pass
@@ -1130,40 +1137,80 @@ def revise_lmp_input_model(
 
 
 def revise_lmp_input_pair_coeff(lmp_lines, jdata=None):
-    """Update pair_coeff lines for D3 support."""
+    """Add explicit DeepMD element mapping and D3 pair coefficients."""
     if jdata is None:
         return lmp_lines
 
     lmp_d3 = jdata.get("lmp_d3", {})
     d3_enabled = lmp_d3.get("enable", False) if lmp_d3 else False
-
-    if not d3_enabled:
-        return lmp_lines
-
-    # D3 requires type maps (element symbols)
     type_map = jdata.get("type_map", [])
     type_map_str = " ".join(type_map)
+    type_map_args = f" {type_map_str}" if type_map_str else ""
 
-    # Find pair_coeff line
-    pair_coeff_idx = None
+    if not d3_enabled and not type_map:
+        return lmp_lines
+
+    pair_style_idx = find_only_one_key(lmp_lines, ["pair_style"])
+    pair_style_tokens = lmp_lines[pair_style_idx].partition("#")[0].split()
+    hybrid_pair_style = pair_style_tokens[1].startswith("hybrid")
+
+    deepmd_coeff_idx = None
+    fallback_coeff_idx = None
+    d3_coeff_idx = None
     for idx, line in enumerate(lmp_lines):
-        if line.strip().startswith("pair_coeff") and "* *" in line:
-            pair_coeff_idx = idx
-            break
+        tokens = line.partition("#")[0].split()
+        if not tokens or tokens[0] != "pair_coeff":
+            continue
+        if "dispersion/d3" in tokens:
+            d3_coeff_idx = idx
+        elif tokens[3:4] == ["deepmd"] and deepmd_coeff_idx is None:
+            deepmd_coeff_idx = idx
+        elif fallback_coeff_idx is None:
+            fallback_coeff_idx = idx
 
-    if pair_coeff_idx is None:
-        # If no pair_coeff found, add them after pair_style
-        pair_style_idx = find_only_one_key(lmp_lines, ["pair_style"])
-        lmp_lines.insert(pair_style_idx + 1, "pair_coeff      * * deepmd\n")
-        lmp_lines.insert(
-            pair_style_idx + 2, f"pair_coeff      * * dispersion/d3 {type_map_str}\n"
+    if deepmd_coeff_idx is None and fallback_coeff_idx is not None:
+        fallback_tokens = lmp_lines[fallback_coeff_idx].partition("#")[0].split()
+        fallback_is_bare = fallback_tokens in (
+            ["pair_coeff"],
+            ["pair_coeff", "*", "*"],
         )
+        if not hybrid_pair_style or (d3_enabled and fallback_is_bare):
+            deepmd_coeff_idx = fallback_coeff_idx
+
+    if deepmd_coeff_idx is None:
+        deepmd_coeff_idx = pair_style_idx + 1
+        style = " deepmd" if d3_enabled or hybrid_pair_style else ""
+        lmp_lines.insert(
+            deepmd_coeff_idx, f"pair_coeff      * *{style}{type_map_args}\n"
+        )
+        if d3_coeff_idx is not None and d3_coeff_idx >= deepmd_coeff_idx:
+            d3_coeff_idx += 1
     else:
-        # Replace existing pair_coeff with D3 version
-        lmp_lines[pair_coeff_idx] = "pair_coeff      * * deepmd\n"
-        lmp_lines.insert(
-            pair_coeff_idx + 1, f"pair_coeff      * * dispersion/d3 {type_map_str}\n"
+        tokens = lmp_lines[deepmd_coeff_idx].partition("#")[0].split()
+        bare_coeff = tokens in (
+            ["pair_coeff"],
+            ["pair_coeff", "*", "*"],
+            ["pair_coeff", "*", "*", "deepmd"],
         )
+        if d3_enabled:
+            if tokens[:3] == ["pair_coeff", "*", "*"]:
+                elements = tokens[4:] if tokens[3:4] == ["deepmd"] else tokens[3:]
+            else:
+                elements = []
+            element_args = f" {' '.join(elements)}" if elements else type_map_args
+            lmp_lines[deepmd_coeff_idx] = f"pair_coeff      * * deepmd{element_args}\n"
+        elif bare_coeff:
+            style = " deepmd" if tokens[3:4] == ["deepmd"] else ""
+            lmp_lines[deepmd_coeff_idx] = f"pair_coeff      * *{style}{type_map_args}\n"
+
+    if d3_enabled:
+        d3_line = f"pair_coeff      * * dispersion/d3 {type_map_str}\n"
+        if d3_coeff_idx is None:
+            lmp_lines.insert(deepmd_coeff_idx + 1, d3_line)
+        else:
+            d3_tokens = lmp_lines[d3_coeff_idx].partition("#")[0].split()
+            if d3_tokens == ["pair_coeff", "*", "*", "dispersion/d3"]:
+                lmp_lines[d3_coeff_idx] = d3_line
 
     return lmp_lines
 

--- a/tests/generator/test_calypso.py
+++ b/tests/generator/test_calypso.py
@@ -8,6 +8,8 @@ import numpy as np
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 __package__ = "generator"
 
+from dpgen.generator.lib.calypso_run_model_devi import _remap_atom_types
+
 from .context import (
     _parse_calypso_dis_mtx,
     _parse_calypso_input,
@@ -94,6 +96,12 @@ class TestCALYPSOScript(unittest.TestCase):
         ndevi = np.loadtxt("model_devi.out")
         self.assertEqual(ndevi[2, 4], model_devi[2, 4])
         os.remove("model_devi.out")
+
+    def test_remap_atom_types_to_model_order(self):
+        """CALYPSO passes model-order type indices to model deviation."""
+        atom_types = np.array([0, 1, 0, 1])
+        remapped = _remap_atom_types(atom_types, ["Mg", "Al"], ["Al", "Mg"])
+        np.testing.assert_array_equal(remapped, [1, 0, 1, 0])
 
     def test_make_calypso_input(self):
         ret = make_calypso_input(

--- a/tests/generator/test_lammps.py
+++ b/tests/generator/test_lammps.py
@@ -56,6 +56,28 @@ class TestMakeLammpsInput(unittest.TestCase):
         self.assertNotIn("hybrid/overlay", result)
         self.assertNotIn("dispersion/d3", result)
 
+    def test_type_map_is_passed_to_deepmd(self):
+        """Map LAMMPS types even when the model order is reversed."""
+        result = make_lammps_input(
+            self.ensemble,
+            self.conf_file,
+            self.graphs,
+            self.nsteps,
+            self.dt,
+            self.neidelay,
+            self.trj_freq,
+            self.mass_map,
+            self.temp,
+            {
+                "type_map": ["Mg", "Al"],
+                "default_training_param": {"model": {"type_map": ["Al", "Mg"]}},
+            },
+            pres=1.0,
+            deepmd_version=self.deepmd_version,
+        )
+
+        self.assertIn("pair_coeff      * * Mg Al\n", result)
+
     def test_d3_enabled_basic(self):
         """Test LAMMPS input with D3 dispersion enabled."""
         jdata = {
@@ -65,7 +87,8 @@ class TestMakeLammpsInput(unittest.TestCase):
                 "functional": "pbe",
                 "cutoff": 30.0,
                 "cn_cutoff": 20.0,
-            }
+            },
+            "type_map": ["H", "O"],
         }
 
         result = make_lammps_input(
@@ -86,6 +109,8 @@ class TestMakeLammpsInput(unittest.TestCase):
         # Should contain hybrid/overlay pair_style
         self.assertIn("pair_style      hybrid/overlay deepmd model.pb", result)
         self.assertIn("dispersion/d3 original pbe 30.0 20.0", result)
+        self.assertIn("pair_coeff      * * deepmd H O", result)
+        self.assertIn("pair_coeff      * * dispersion/d3 H O", result)
 
         # Should contain both pair_coeff lines
         lines = result.split("\n")

--- a/tests/generator/test_make_md.py
+++ b/tests/generator/test_make_md.py
@@ -10,7 +10,11 @@ import unittest
 import dpdata
 import numpy as np
 
-from dpgen.generator.run import _read_model_devi_file, parse_cur_job_sys_revmat
+from dpgen.generator.run import (
+    _read_model_devi_file,
+    parse_cur_job_sys_revmat,
+    revise_lmp_input_pair_coeff,
+)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 __package__ = "generator"
@@ -580,6 +584,52 @@ class TestParseCurJobSysRevMat(unittest.TestCase):
 
 
 class MakeModelDeviByReviseMatrix(unittest.TestCase):
+    def test_revise_lmp_input_pair_coeff_adds_type_map(self):
+        """Template LAMMPS inputs map top-level types to model elements."""
+        jdata = {"type_map": ["C", "Cl", "H", "O"]}
+        cases = (
+            ("pair_coeff\n", "pair_coeff      * * C Cl H O\n"),
+            ("pair_coeff * *\n", "pair_coeff      * * C Cl H O\n"),
+            (
+                "pair_coeff * * deepmd\n",
+                "pair_coeff      * * deepmd C Cl H O\n",
+            ),
+        )
+
+        for pair_coeff, expected in cases:
+            with self.subTest(pair_coeff=pair_coeff):
+                lines = ["pair_style deepmd graph.pb\n", pair_coeff]
+                result = revise_lmp_input_pair_coeff(lines, jdata)
+                self.assertEqual(result[1], expected)
+
+    def test_revise_lmp_input_pair_coeff_preserves_explicit_mapping(self):
+        """Do not replace a user-provided LAMMPS element mapping."""
+        jdata = {"type_map": ["C", "Cl", "H", "O"]}
+        for pair_coeff in (
+            "pair_coeff * * H O\n",
+            "pair_coeff * * deepmd H O\n",
+        ):
+            with self.subTest(pair_coeff=pair_coeff):
+                lines = ["pair_style deepmd graph.pb\n", pair_coeff]
+                result = revise_lmp_input_pair_coeff(lines, jdata)
+                self.assertEqual(result[1], pair_coeff)
+
+    def test_revise_lmp_input_pair_coeff_d3_is_idempotent(self):
+        """Repeated template revisions retain one mapping per interaction."""
+        jdata = {
+            "type_map": ["C", "Cl", "H", "O"],
+            "lmp_d3": {"enable": True},
+        }
+        lines = ["pair_style deepmd graph.pb\n", "pair_coeff * *\n"]
+
+        result = revise_lmp_input_pair_coeff(lines, jdata)
+        result = revise_lmp_input_pair_coeff(result, jdata)
+
+        self.assertEqual(result.count("pair_coeff      * * deepmd C Cl H O\n"), 1)
+        self.assertEqual(
+            result.count("pair_coeff      * * dispersion/d3 C Cl H O\n"), 1
+        )
+
     def test_find_only_one_key_1(self):
         lines = ["aaa bbb ccc\n", "bbb ccc\n", "ccc bbb ccc\n"]
         idx = find_only_one_key(lines, ["bbb", "ccc"])

--- a/tests/generator/test_make_train.py
+++ b/tests/generator/test_make_train.py
@@ -592,9 +592,7 @@ class TestMakeTrain(unittest.TestCase):
             with open(machine_name) as fp:
                 mdata = json.load(fp)
             make_train(0, jdata, mdata)
-            input_path = os.path.join(
-                "iter.000000", "00.train", "000", "input.json"
-            )
+            input_path = os.path.join("iter.000000", "00.train", "000", "input.json")
             with open(input_path) as fp:
                 model_input = json.load(fp)
             self.assertEqual(model_input["model"]["type_map"], ["Al", "Mg"])
@@ -604,9 +602,7 @@ class TestMakeTrain(unittest.TestCase):
                 jdata = json.load(fp)
             jdata["default_training_param"]["model"].pop("type_map", None)
             make_train(0, jdata, mdata)
-            input_path = os.path.join(
-                "iter.000000", "00.train", "000", "input.json"
-            )
+            input_path = os.path.join("iter.000000", "00.train", "000", "input.json")
             with open(input_path) as fp:
                 model_input = json.load(fp)
             self.assertNotIn("type_map", model_input["model"])

--- a/tests/generator/test_make_train.py
+++ b/tests/generator/test_make_train.py
@@ -580,6 +580,38 @@ class TestMakeTrain(unittest.TestCase):
         # remove testing dirs
         shutil.rmtree("iter.000000")
 
+    def test_model_type_map_is_not_overwritten(self):
+        """Keep explicit model maps and do not inject the top-level map."""
+        for param_name, machine_name in (
+            (param_file_v1, machine_file_v1),
+            (param_file, machine_file),
+        ):
+            with open(param_name) as fp:
+                jdata = json.load(fp)
+            jdata["default_training_param"]["model"]["type_map"] = ["Al", "Mg"]
+            with open(machine_name) as fp:
+                mdata = json.load(fp)
+            make_train(0, jdata, mdata)
+            input_path = os.path.join(
+                "iter.000000", "00.train", "000", "input.json"
+            )
+            with open(input_path) as fp:
+                model_input = json.load(fp)
+            self.assertEqual(model_input["model"]["type_map"], ["Al", "Mg"])
+            shutil.rmtree("iter.000000")
+
+            with open(param_name) as fp:
+                jdata = json.load(fp)
+            jdata["default_training_param"]["model"].pop("type_map", None)
+            make_train(0, jdata, mdata)
+            input_path = os.path.join(
+                "iter.000000", "00.train", "000", "input.json"
+            )
+            with open(input_path) as fp:
+                model_input = json.load(fp)
+            self.assertNotIn("type_map", model_input["model"])
+            shutil.rmtree("iter.000000")
+
     def test_training_init_frozen_model(self):
         """Test `training_init_frozen_model`."""
         with open(param_file_v1) as fp:

--- a/tests/generator/test_make_train.py
+++ b/tests/generator/test_make_train.py
@@ -13,6 +13,7 @@ import numpy as np
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 __package__ = "generator"
 import tempfile
+from unittest.mock import patch
 
 from .context import (
     machine_file,
@@ -581,11 +582,13 @@ class TestMakeTrain(unittest.TestCase):
         shutil.rmtree("iter.000000")
 
     def test_model_type_map_is_not_overwritten(self):
-        """Keep explicit model maps and do not inject the top-level map."""
+        """Keep explicit model maps for TensorFlow training inputs."""
         for param_name, machine_name in (
             (param_file_v1, machine_file_v1),
             (param_file, machine_file),
         ):
+            if os.path.isdir("iter.000000"):
+                shutil.rmtree("iter.000000")
             with open(param_name) as fp:
                 jdata = json.load(fp)
             jdata["default_training_param"]["model"]["type_map"] = ["Al", "Mg"]
@@ -607,6 +610,41 @@ class TestMakeTrain(unittest.TestCase):
                 model_input = json.load(fp)
             self.assertNotIn("type_map", model_input["model"])
             shutil.rmtree("iter.000000")
+
+    def test_pytorch_3_uses_top_level_type_map_as_fallback(self):
+        """DeePMD-kit 3.x PyTorch needs a model type_map to train."""
+
+        def copy_directory(source, target):
+            shutil.copytree(source, target)
+
+        for model_type_map in (None, ["Al", "Mg"]):
+            with self.subTest(model_type_map=model_type_map):
+                if os.path.isdir("iter.000000"):
+                    shutil.rmtree("iter.000000")
+                with open(param_file) as fp:
+                    jdata = json.load(fp)
+                jdata["train_backend"] = "pytorch"
+                if model_type_map is None:
+                    jdata["default_training_param"]["model"].pop("type_map", None)
+                else:
+                    jdata["default_training_param"]["model"]["type_map"] = (
+                        model_type_map
+                    )
+
+                with patch(
+                    "dpgen.generator.run.os.symlink", side_effect=copy_directory
+                ):
+                    make_train(0, jdata, {"deepmd_version": "3.0"})
+                input_path = os.path.join(
+                    "iter.000000", "00.train", "000", "input.json"
+                )
+                with open(input_path) as fp:
+                    model_input = json.load(fp)
+                self.assertEqual(
+                    model_input["model"]["type_map"],
+                    jdata["type_map"] if model_type_map is None else model_type_map,
+                )
+                shutil.rmtree("iter.000000")
 
     def test_training_init_frozen_model(self):
         """Test `training_init_frozen_model`."""


### PR DESCRIPTION
## Summary

Follow-up to #1926 and the `@hcustc` review comment about DP-GEN overwriting an explicitly configured pretrained model `type_map`.

The two legacy assignments in `make_train_dp` unconditionally copied the top-level DP-GEN `type_map` into `default_training_param.model.type_map`. They predate #1926 and are no longer needed: DeePMD treats `model.type_map` as optional and handles system data through its type indices and `type_map.raw` mapping.

This PR removes both assignments for DeePMD 1.x and 2.x generation paths. Explicitly configured `model.type_map` values are preserved; omitted values are no longer injected. The top-level `type_map` remains unchanged for DP-GEN system and downstream mappings.

## Validation

- Added regression coverage for DeePMD 1.x and 2.x input generation.
- Verified explicit model maps are preserved and omitted model maps remain omitted.
- `python -m compileall` and `git diff --check` pass.

Full pytest was attempted but stalled during test-module initialization in the current Windows environment.

Follow-up for #1926; no changes are made to that PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved type-map handling across training, model-deviation analysis, and LAMMPS workflows, preserving configured element order and providing reliable fallbacks.
  - Added support for selecting model filename suffixes in CALYPSO workflows.
  - CALYPSO model-deviation calculations now correctly translate atom types between model and input ordering.

- **Bug Fixes**
  - Normalized singleton CALYPSO settings to valid scalar values.
  - Improved portability of test configuration paths.

- **Tests**
  - Added coverage for type-map fallbacks, reordered mappings, model suffixes, and CALYPSO input formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->